### PR TITLE
Refactor Profile and TabMenu: Ionic-Lifecycle

### DIFF
--- a/frontend/src/app/features/tabs/profile/profile.component.spec.ts
+++ b/frontend/src/app/features/tabs/profile/profile.component.spec.ts
@@ -46,7 +46,7 @@ describe('ProfileComponent', () => {
     const fixture = TestBed.createComponent(ProfileComponent);
     const component = fixture.componentInstance;
 
-    component.ngOnInit();
+    component.ionViewWillEnter();
 
     expect(userServiceSpy.getProfile).toHaveBeenCalled();
     expect(component.profile).toEqual(mockProfile);

--- a/frontend/src/app/features/tabs/profile/profile.component.ts
+++ b/frontend/src/app/features/tabs/profile/profile.component.ts
@@ -4,6 +4,7 @@ import { IonicStandaloneStandardImports } from '../../../shared/ionic-imports';
 import { UserService } from '../../../shared/services/user.service';
 import { AuthService } from '../../../shared/services/auth.service';
 import { Router } from '@angular/router';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-profile',
@@ -14,14 +15,15 @@ import { Router } from '@angular/router';
     CommonModule, ...IonicStandaloneStandardImports
   ],
 })
-export class ProfileComponent implements OnInit {
+export class ProfileComponent {
+  private profileSubscription: Subscription|null = null;
   profile: any;
 
   constructor(private readonly userService: UserService, private readonly authService: AuthService, private readonly router: Router) {
   }
 
-  ngOnInit() {
-    this.userService.getProfile().subscribe({
+  ionViewWillEnter() {
+    this.profileSubscription = this.userService.getProfile().subscribe({
       next: response => {
         this.profile = response;
       },
@@ -29,6 +31,10 @@ export class ProfileComponent implements OnInit {
         console.error('Profile Error:', err);
       }
     })
+  }
+  
+  ionViewWillLeave() {
+    this.profileSubscription?.unsubscribe();
   }
 
   logout() {

--- a/frontend/src/app/features/tabs/profile/profile.component.ts
+++ b/frontend/src/app/features/tabs/profile/profile.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { IonicStandaloneStandardImports } from '../../../shared/ionic-imports';
 import { UserService } from '../../../shared/services/user.service';
 import { AuthService } from '../../../shared/services/auth.service';

--- a/frontend/src/app/features/tabs/tab-menu/tab-menu.component.spec.ts
+++ b/frontend/src/app/features/tabs/tab-menu/tab-menu.component.spec.ts
@@ -55,6 +55,7 @@ describe('TabMenuComponent', () => {
   it('should have a "profile" tab, when logged in', () => {
     TestBed.overrideProvider(AuthService, provideMockAuthService(true));
     const fixture = TestBed.createComponent(TabMenuComponent);
+    fixture.componentInstance.ionViewWillEnter();
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
     const profileTab = compiled.querySelector('ion-tab-button[tab="profile"]');

--- a/frontend/src/app/features/tabs/tab-menu/tab-menu.component.ts
+++ b/frontend/src/app/features/tabs/tab-menu/tab-menu.component.ts
@@ -1,7 +1,8 @@
 import { CommonModule } from '@angular/common';
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { IonicStandaloneStandardImports } from '../../../shared/ionic-imports';
 import { AuthService } from '../../../shared/services/auth.service';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-tab-menu',
@@ -13,10 +14,11 @@ import { AuthService } from '../../../shared/services/auth.service';
   ]
 })
 export class TabMenuComponent {
+  private authSubscription: Subscription|null = null;
   isAuthenticated: boolean = false;
   constructor(private readonly authService: AuthService) { }
 
-  ngOnInit() {
+  ionViewWillEnter() {
     this.authService.getAuthenticationStatusObservable().subscribe({
       next: response => {
         this.isAuthenticated = response;
@@ -24,4 +26,7 @@ export class TabMenuComponent {
     })
   }
 
+  ionViewWillLeave() {
+    this.authSubscription?.unsubscribe();
+  }
 }

--- a/frontend/src/app/features/tabs/tab-menu/tab-menu.component.ts
+++ b/frontend/src/app/features/tabs/tab-menu/tab-menu.component.ts
@@ -19,7 +19,7 @@ export class TabMenuComponent {
   constructor(private readonly authService: AuthService) { }
 
   ionViewWillEnter() {
-    this.authService.getAuthenticationStatusObservable().subscribe({
+    this.authSubscription = this.authService.getAuthenticationStatusObservable().subscribe({
       next: response => {
         this.isAuthenticated = response;
       }

--- a/frontend/src/app/shared/services/user.service.ts
+++ b/frontend/src/app/shared/services/user.service.ts
@@ -24,7 +24,6 @@ export class UserService {
   }
 
   private reloadProfile(): void {
-    console.log('getProfile');
     this.apiService.get('/user/me').subscribe(profile => {
       this.profile.next(profile);
     });


### PR DESCRIPTION
Profile und TabMenu verwendet neu die LifeCycle-Hooks von Ionic, damit die Klassen korrekt subscriben/unsubscriben vom Service-State. Muss nur so bei Top-Level-Page-Elementen gemacht werden, Child-Components haben den normalen LifeCycle.

Gerne selbstständig mergen.