### PR TITLE
frontend for Rit view/edit

### DIFF
--- a/frontend/src/app/app.routes.spec.ts
+++ b/frontend/src/app/app.routes.spec.ts
@@ -29,7 +29,7 @@ describe('App Routing', () => {
         provideRouter(routes),
         provideHttpClient(),
         provideHttpClientTesting(),
-        provideMockAuthService(false)
+        provideMockAuthService(true)
       ],
     }).compileComponents();
 
@@ -38,6 +38,9 @@ describe('App Routing', () => {
   }));
 
   it('should not navigate to /profile (empty instead) if not authenticated', waitForAsync(async () => {
+    const authServiceSpy = TestBed.inject(AuthService) as jasmine.SpyObj<AuthService>;
+    authServiceSpy.isAuthenticated.and.returnValue(false);
+    
     const fixture = TestBed.createComponent(TestHostComponent);
     fixture.detectChanges();
 
@@ -108,5 +111,35 @@ describe('App Routing', () => {
     fixture.detectChanges();
 
     expect(location.path()).toBe('/home');
+  }));
+
+  it('should navigate to /rits', waitForAsync(async () => {
+    const fixture = TestBed.createComponent(TestHostComponent);
+    fixture.detectChanges();
+
+    await router.navigate(['/rits']);
+    fixture.detectChanges();
+
+    expect(location.path()).toBe('/rits');
+  }));
+
+  it('should navigate to /rits/view/12', waitForAsync(async () => {
+    const fixture = TestBed.createComponent(TestHostComponent);
+    fixture.detectChanges();
+
+    await router.navigate(['/rits/view/12']);
+    fixture.detectChanges();
+
+    expect(location.path()).toBe('/rits/view/12');
+  }));
+
+  it('should navigate to /ratings/12', waitForAsync(async () => {
+    const fixture = TestBed.createComponent(TestHostComponent);
+    fixture.detectChanges();
+
+    await router.navigate(['/ratings/12']);
+    fixture.detectChanges();
+
+    expect(location.path()).toBe('/ratings/12');
   }));
 });

--- a/frontend/src/app/app.routes.spec.ts
+++ b/frontend/src/app/app.routes.spec.ts
@@ -133,13 +133,13 @@ describe('App Routing', () => {
     expect(location.path()).toBe('/rits/view/12');
   }));
 
-  it('should navigate to /ratings/12', waitForAsync(async () => {
+  it('should navigate to /rits/ratings/12', waitForAsync(async () => {
     const fixture = TestBed.createComponent(TestHostComponent);
     fixture.detectChanges();
 
-    await router.navigate(['/ratings/12']);
+    await router.navigate(['/rits/ratings/12']);
     fixture.detectChanges();
 
-    expect(location.path()).toBe('/ratings/12');
+    expect(location.path()).toBe('/rits/ratings/12');
   }));
 });

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -19,6 +19,7 @@ export const routes: Routes = [
       {
         path: 'rits/view/:ritId',
         loadComponent: () => import('./features/rit/rit-create/rit-create.component').then(m => m.RitCreateComponent),
+        canActivate: [AuthGuard],
         data: { mode: 'view' }
       },
       {

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -23,7 +23,7 @@ export const routes: Routes = [
         data: { mode: 'view' }
       },
       {
-        path: 'ratings/:ritId',
+        path: 'rits/ratings/:ritId',
         pathMatch: 'full',
         loadComponent: () => import('./features/rating/all-ratings/all-ratings.component').then((m) => m.AllRatingsComponent),
         canActivate: [AuthGuard],

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -41,6 +41,11 @@ export const routes: Routes = [
     ],
   },
   {
+    path: 'rits/view/:id',
+    loadComponent: () => import('./features/rit/rit-create/rit-create.component').then(m => m.RitCreateComponent),
+    data: { mode: 'view' }
+  },
+  {
     path: '',
     redirectTo: '/home',
     pathMatch: 'full',

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -17,6 +17,11 @@ export const routes: Routes = [
         canActivate: [AuthGuard],
       },
       {
+        path: 'rits/view/:ritId',
+        loadComponent: () => import('./features/rit/rit-create/rit-create.component').then(m => m.RitCreateComponent),
+        data: { mode: 'view' }
+      },
+      {
         path: 'ratings/:ritId',
         pathMatch: 'full',
         loadComponent: () => import('./features/rating/all-ratings/all-ratings.component').then((m) => m.AllRatingsComponent),
@@ -45,11 +50,6 @@ export const routes: Routes = [
         pathMatch: 'full',
       },
     ],
-  },
-  {
-    path: 'rits/view/:id',
-    loadComponent: () => import('./features/rit/rit-create/rit-create.component').then(m => m.RitCreateComponent),
-    data: { mode: 'view' }
   },
   {
     path: '',

--- a/frontend/src/app/features/rating/all-ratings/all-ratings.component.html
+++ b/frontend/src/app/features/rating/all-ratings/all-ratings.component.html
@@ -1,5 +1,8 @@
 <ion-header>
   <ion-toolbar>
+    <ion-buttons slot="start">
+      <ion-back-button defaultHref="/rits"></ion-back-button>
+    </ion-buttons>
     <ion-title>Ratings</ion-title>
   </ion-toolbar>
 </ion-header>

--- a/frontend/src/app/features/rating/all-ratings/all-ratings.component.ts
+++ b/frontend/src/app/features/rating/all-ratings/all-ratings.component.ts
@@ -1,7 +1,7 @@
 import {Component} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {ReactiveFormsModule} from '@angular/forms';
-import { ToastController } from '@ionic/angular/standalone';
+import { IonBackButton,ToastController } from '@ionic/angular/standalone';
 import {IonicStandaloneStandardImports} from '../../../shared/ionic-imports';
 import {Rating} from '../../../model/rating';
 import {RatingListItemComponent} from '../rating-list-item/rating-list-item.component';
@@ -14,7 +14,7 @@ import { ActivatedRoute } from '@angular/router';
   styleUrls: ['./all-ratings.component.scss'],
   standalone: true,
   imports: [
-    CommonModule, ReactiveFormsModule, ...IonicStandaloneStandardImports, RatingListItemComponent
+    CommonModule, ReactiveFormsModule, ...IonicStandaloneStandardImports, RatingListItemComponent, IonBackButton
   ],
 })
 

--- a/frontend/src/app/features/rit/rit-create/rit-create.component.html
+++ b/frontend/src/app/features/rit/rit-create/rit-create.component.html
@@ -6,7 +6,7 @@
     <ion-title>Rit</ion-title>
 
     <ion-buttons slot="end" *ngIf="mode === 'edit'">
-      <ion-button [disabled]="!ritName?.trim()" (click)="updateRit()">
+      <ion-button [disabled]="!ritName?.trim()" (click)="updateRit()" (keydown.enter)="updateRit()">
         Confirm
       </ion-button>
     </ion-buttons>
@@ -67,7 +67,7 @@
   </ion-card>
 
   <ion-fab vertical="bottom" horizontal="end" slot="fixed" *ngIf="mode === 'view'">
-    <ion-fab-button class="edit-button" (click)="mode = 'edit'">
+    <ion-fab-button class="edit-button" (click)="mode = 'edit'" (keydown.enter)="mode = 'edit'">
       <ion-icon name="create-outline"></ion-icon>
     </ion-fab-button>
   </ion-fab>

--- a/frontend/src/app/features/rit/rit-create/rit-create.component.html
+++ b/frontend/src/app/features/rit/rit-create/rit-create.component.html
@@ -10,8 +10,8 @@
         Rit Name
       </ion-card-subtitle>
     </ion-card-header>
-    <ion-card-content class="name-error-container">
-      <ion-text color="danger" *ngIf="ritNameErrorMessage">
+    <ion-card-content *ngIf="ritNameErrorMessage" class="name-error-container">
+      <ion-text color="danger">
         <p>{{ritNameErrorMessage}}</p>
       </ion-text>
     </ion-card-content>
@@ -28,8 +28,8 @@
         placeholder="Enter Tag" (keyup.enter)="addTag(tagInput, 'enter')"
         (ionBlur)="addTag(tagInput, 'blur')"></ion-input>
     </ion-card-content>
-    <ion-card-content class="tags-error-container">
-      <ion-text color="danger" *ngIf="tagsErrorMessage">
+    <ion-card-content *ngIf="tagsErrorMessage" class="tags-error-container">
+      <ion-text color="danger">
         <p>{{tagsErrorMessage}}</p>
       </ion-text>
     </ion-card-content>

--- a/frontend/src/app/features/rit/rit-create/rit-create.component.html
+++ b/frontend/src/app/features/rit/rit-create/rit-create.component.html
@@ -13,8 +13,7 @@
   </ion-toolbar>
 </ion-header>
 
-<ion-content class="ion-padding">
-
+<ion-content>
   <ion-card>
     <ion-card-header>
       <ion-card-title class="rit-title-container">

--- a/frontend/src/app/features/rit/rit-create/rit-create.component.html
+++ b/frontend/src/app/features/rit/rit-create/rit-create.component.html
@@ -1,10 +1,20 @@
+<ion-header *ngIf="mode !== 'create'">
+  <ion-toolbar>
+    <ion-buttons slot="start">
+      <ion-back-button defaultHref="/rits"></ion-back-button>
+    </ion-buttons>
+    <ion-title>Rit</ion-title>
+  </ion-toolbar>
+</ion-header>
+
 <ion-content class="ion-padding">
 
   <ion-card>
     <ion-card-header>
       <ion-card-title>
-        <ion-input data-testid="rit-name-input" ngModel [required]="true" [value]="ritName"
-          (ionInput)="setRitName($event)" placeholder="Rit Name..."></ion-input>
+        <ion-input [readonly]="mode === 'view'" [value]="ritName" (ionInput)="setRitName($event)"
+          placeholder="Rit Name...">
+        </ion-input>
       </ion-card-title>
       <ion-card-subtitle>
         Rit Name
@@ -17,15 +27,15 @@
     </ion-card-content>
 
     <ion-card-content class="tags-container">
-      <ion-chip color="primary" *ngFor="let tag of tags; let i = index" (click)="removeTag(i)"
-        (keydown.enter)="removeTag(i)" [attr.data-testid]="'tag-chip-' + i">
+      <ion-chip [disabled]="mode === 'view'" color="primary" *ngFor="let tag of tags; let i = index"
+        (click)="removeTag(i)" (keydown.enter)="removeTag(i)" [attr.data-testid]="'tag-chip-' + i">
         <ion-icon name="pricetag-outline"></ion-icon>
         <ion-label>{{ tag }}</ion-label>
         <ion-icon name="close"></ion-icon>
       </ion-chip>
 
-      <ion-input #tagInput class="tag-input" data-testid="new-tag-input" [value]="newTag" (ionInput)="setNewTag($event)"
-        placeholder="Enter Tag" (keyup.enter)="addTag(tagInput, 'enter')"
+      <ion-input *ngIf="mode !== 'view'" #tagInput class="tag-input" data-testid="new-tag-input" [value]="newTag"
+        (ionInput)="setNewTag($event)" placeholder="Enter Tag" (keyup.enter)="addTag(tagInput, 'enter')"
         (ionBlur)="addTag(tagInput, 'blur')"></ion-input>
     </ion-card-content>
     <ion-card-content *ngIf="tagsErrorMessage" class="tags-error-container">
@@ -41,9 +51,9 @@
     </ion-card-header>
 
     <ion-card-content>
-      <ion-textarea data-testid="details-textarea" [value]="details" (ionInput)="setDetails($event)"
-        label="Enter your Description" [autoGrow]="true" labelPlacement="floating" fill="outline"
-        placeholder="Enter text"></ion-textarea>
+      <ion-textarea [readonly]="mode === 'view'" [disabled]="mode === 'view'" [value]="details"
+        (ionInput)="setDetails($event)" placeholder="Enter text">
+      </ion-textarea>
       <ion-text color="danger" *ngIf="detailsErrorMessage">
         <p>{{detailsErrorMessage}}</p>
       </ion-text>

--- a/frontend/src/app/features/rit/rit-create/rit-create.component.html
+++ b/frontend/src/app/features/rit/rit-create/rit-create.component.html
@@ -6,7 +6,7 @@
     <ion-title>Rit</ion-title>
 
     <ion-buttons slot="end" *ngIf="mode === 'edit'">
-      <ion-button [disabled]="!ritName?.trim()" (click)="confirmEdit()">
+      <ion-button [disabled]="!ritName?.trim()" (click)="updateRit()">
         Confirm
       </ion-button>
     </ion-buttons>

--- a/frontend/src/app/features/rit/rit-create/rit-create.component.html
+++ b/frontend/src/app/features/rit/rit-create/rit-create.component.html
@@ -58,7 +58,7 @@
 
     <ion-card-content>
       <ion-textarea [readonly]="mode === 'view'" [disabled]="mode === 'view'" [value]="details"
-        (ionInput)="setDetails($event)">
+        (ionInput)="setDetails($event)" placeholder="Details..." [autoGrow]="true">
       </ion-textarea>
       <ion-text color="danger" *ngIf="detailsErrorMessage">
         <p>{{detailsErrorMessage}}</p>

--- a/frontend/src/app/features/rit/rit-create/rit-create.component.html
+++ b/frontend/src/app/features/rit/rit-create/rit-create.component.html
@@ -58,7 +58,7 @@
 
     <ion-card-content>
       <ion-textarea [readonly]="mode === 'view'" [disabled]="mode === 'view'" [value]="details"
-        (ionInput)="setDetails($event)" placeholder="Enter text">
+        (ionInput)="setDetails($event)">
       </ion-textarea>
       <ion-text color="danger" *ngIf="detailsErrorMessage">
         <p>{{detailsErrorMessage}}</p>

--- a/frontend/src/app/features/rit/rit-create/rit-create.component.html
+++ b/frontend/src/app/features/rit/rit-create/rit-create.component.html
@@ -4,6 +4,12 @@
       <ion-back-button defaultHref="/rits"></ion-back-button>
     </ion-buttons>
     <ion-title>Rit</ion-title>
+
+    <ion-buttons slot="end" *ngIf="mode === 'edit'">
+      <ion-button [disabled]="!ritName?.trim()" (click)="confirmEdit()">
+        Confirm
+      </ion-button>
+    </ion-buttons>
   </ion-toolbar>
 </ion-header>
 
@@ -11,7 +17,7 @@
 
   <ion-card>
     <ion-card-header>
-      <ion-card-title>
+      <ion-card-title class="rit-title-container">
         <ion-input [readonly]="mode === 'view'" [value]="ritName" (ionInput)="setRitName($event)"
           placeholder="Rit Name...">
         </ion-input>
@@ -59,5 +65,11 @@
       </ion-text>
     </ion-card-content>
   </ion-card>
+
+  <ion-fab vertical="bottom" horizontal="end" slot="fixed" *ngIf="mode === 'view'">
+    <ion-fab-button class="edit-button" (click)="mode = 'edit'">
+      <ion-icon name="create-outline"></ion-icon>
+    </ion-fab-button>
+  </ion-fab>
 
 </ion-content>

--- a/frontend/src/app/features/rit/rit-create/rit-create.component.scss
+++ b/frontend/src/app/features/rit/rit-create/rit-create.component.scss
@@ -16,3 +16,18 @@ ion-chip {
   flex: 1 1 150px;
   margin-left: 1vw;
 }
+
+.rit-title-container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.edit-button {
+  --background: var(--custom-color-accent);
+  --background-hover: var(--custom-color-accent-darker);
+  --background-activated: var(--custom-color-accent-darker);
+  --background-focused: var(--custom-color-accent-darker);
+
+  --color: var(--ion-text-color);
+}

--- a/frontend/src/app/features/rit/rit-create/rit-create.component.spec.ts
+++ b/frontend/src/app/features/rit/rit-create/rit-create.component.spec.ts
@@ -225,11 +225,9 @@ describe('RitCreateComponent', () => {
       tags: ['tag1', 'tag2']
     };
   
-    // Patch ActivatedRoute to return a ritId
     const route = TestBed.inject(ActivatedRoute);
     spyOn(route.snapshot.paramMap, 'get').and.returnValue('test-id');
   
-    // Mock getRit
     ritServiceSpy.getRit = jasmine.createSpy().and.returnValue(of(mockRit));
   
     component.ionViewWillEnter();

--- a/frontend/src/app/features/rit/rit-create/rit-create.component.spec.ts
+++ b/frontend/src/app/features/rit/rit-create/rit-create.component.spec.ts
@@ -143,21 +143,21 @@ describe('RitCreateComponent', () => {
   it('should call updateRit and show success toast on success', fakeAsync(() => {
     const toast = { present: jasmine.createSpy().and.returnValue(Promise.resolve()) };
     toastControllerSpy.create.and.returnValue(Promise.resolve(toast as any));
-  
+
     component.ritId = '123';
     component.ritName = 'Test Rit';
     component.details = 'Details';
     component.tags = ['tag1'];
-  
+
     ritServiceSpy.updateRit.and.returnValue(of({
       name: 'Test Rit',
       details: 'Details',
       tags: ['tag1']
     }));
-  
+
     component.updateRit();
     tick();
-  
+
     expect(ritServiceSpy.updateRit).toHaveBeenCalled();
     expect(toastControllerSpy.create).toHaveBeenCalledWith(jasmine.objectContaining({ message: 'Rit updated successfully!' }));
     expect(toastControllerSpy.create).toHaveBeenCalledWith(jasmine.objectContaining({ color: 'success' }));

--- a/frontend/src/app/features/rit/rit-create/rit-create.component.spec.ts
+++ b/frontend/src/app/features/rit/rit-create/rit-create.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
@@ -14,6 +14,9 @@ describe('RitCreateComponent', () => {
   let fixture: ComponentFixture<RitCreateComponent>;
   let modalCtrlSpy = jasmine.createSpyObj('ModalController', ['create']);
   let ritServiceSpy = jasmine.createSpyObj('RitService', ['createRit', 'updateRit', 'triggerRitsReload']);
+  ritServiceSpy.createRit.and.returnValue(of({}));
+  ritServiceSpy.updateRit.and.returnValue(of({}));
+  ritServiceSpy.triggerRitsReload.and.returnValue(of({}));
   let activatedRouteSpy = { snapshot: { paramMap: { get: () => null } } };
   let toastControllerSpy = jasmine.createSpyObj('ToastController', ['create']);
 
@@ -136,6 +139,30 @@ describe('RitCreateComponent', () => {
     expect(toastControllerSpy.create).toHaveBeenCalledWith(jasmine.objectContaining({ color: 'success' }));
     expect(toast.present).toHaveBeenCalled();
   });
+
+  it('should call updateRit and show success toast on success', fakeAsync(() => {
+    const toast = { present: jasmine.createSpy().and.returnValue(Promise.resolve()) };
+    toastControllerSpy.create.and.returnValue(Promise.resolve(toast as any));
+  
+    component.ritId = '123';
+    component.ritName = 'Test Rit';
+    component.details = 'Details';
+    component.tags = ['tag1'];
+  
+    ritServiceSpy.updateRit.and.returnValue(of({
+      name: 'Test Rit',
+      details: 'Details',
+      tags: ['tag1']
+    }));
+  
+    component.updateRit();
+    tick();
+  
+    expect(ritServiceSpy.updateRit).toHaveBeenCalled();
+    expect(toastControllerSpy.create).toHaveBeenCalledWith(jasmine.objectContaining({ message: 'Rit updated successfully!' }));
+    expect(toastControllerSpy.create).toHaveBeenCalledWith(jasmine.objectContaining({ color: 'success' }));
+    expect(toast.present).toHaveBeenCalled();
+  }));
 
   it('should call createRit and show error toast on unknown error', async () => {
     const toast = { present: jasmine.createSpy() };

--- a/frontend/src/app/features/rit/rit-create/rit-create.component.spec.ts
+++ b/frontend/src/app/features/rit/rit-create/rit-create.component.spec.ts
@@ -217,4 +217,29 @@ describe('RitCreateComponent', () => {
     expect(component.tagsErrorMessage).toEqual('invalid tag');
   });
 
+  it('should load rit data in ionViewWillEnter if ritId is present', () => {
+    const mockRit = {
+      id: 'test-id',
+      name: 'Loaded Rit',
+      details: 'Some loaded details',
+      tags: ['tag1', 'tag2']
+    };
+  
+    // Patch ActivatedRoute to return a ritId
+    const route = TestBed.inject(ActivatedRoute);
+    spyOn(route.snapshot.paramMap, 'get').and.returnValue('test-id');
+  
+    // Mock getRit
+    ritServiceSpy.getRit = jasmine.createSpy().and.returnValue(of(mockRit));
+  
+    component.ionViewWillEnter();
+  
+    expect(component.ritId).toBe('test-id');
+    expect(component.mode).toBe('view');
+    expect(ritServiceSpy.getRit).toHaveBeenCalledWith('test-id');
+    expect(component.ritName).toBe(mockRit.name);
+    expect(component.details).toBe(mockRit.details);
+    expect(component.tags).toEqual(mockRit.tags);
+  });
+
 });

--- a/frontend/src/app/features/rit/rit-create/rit-create.component.spec.ts
+++ b/frontend/src/app/features/rit/rit-create/rit-create.component.spec.ts
@@ -1,20 +1,32 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
+import { ActivatedRoute } from '@angular/router';
 import { IonicModule } from '@ionic/angular';
-import { ModalController } from '@ionic/angular/standalone';
+import { ModalController, ToastController } from '@ionic/angular/standalone';
+import { of } from 'rxjs/internal/observable/of';
+import { throwError } from 'rxjs/internal/observable/throwError';
+import { RitService } from '../../../shared/services/rit.service';
 import { RitCreateComponent } from './rit-create.component';
 
 describe('RitCreateComponent', () => {
   let component: RitCreateComponent;
   let fixture: ComponentFixture<RitCreateComponent>;
   let modalCtrlSpy = jasmine.createSpyObj('ModalController', ['create']);
+  let ritServiceSpy = jasmine.createSpyObj('RitService', ['createRit', 'updateRit', 'triggerRitsReload']);
+  let activatedRouteSpy = { snapshot: { paramMap: { get: () => null } } };
+  let toastControllerSpy = jasmine.createSpyObj('ToastController', ['create']);
+
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [RitCreateComponent, IonicModule.forRoot(), FormsModule],
       providers: [
-        { provide: ModalController, useValue: modalCtrlSpy }
+        { provide: ModalController, useValue: modalCtrlSpy },
+        { provide: RitService, useValue: ritServiceSpy },
+        { provide: ActivatedRoute, useValue: activatedRouteSpy },
+        { provide: ToastController, useValue: toastControllerSpy }
+
       ]
     }).compileComponents();
 
@@ -26,15 +38,6 @@ describe('RitCreateComponent', () => {
     fixture.detectChanges();
     expect(component).toBeTruthy();
   });
-
-  it('should render ritName in the ion-input', () => {
-    component.ritName = 'Test Rit';
-    fixture.detectChanges();
-
-    const input = fixture.debugElement.query(By.css('[data-testid="rit-name-input"]'));
-    expect(input.attributes['ng-reflect-value']).toContain('Test Rit');
-  });
-
 
   it('should display all tag chips', () => {
     component.tags = ['red', 'blue', 'green'];
@@ -52,14 +55,6 @@ describe('RitCreateComponent', () => {
 
     const newTagInput = fixture.debugElement.query(By.css('[data-testid="new-tag-input"]'));
     expect(newTagInput.attributes['ng-reflect-value']).toContain('hafermilch');
-  });
-
-  it('should render the details text in ion-textarea', () => {
-    component.details = 'Here are the details.';
-    fixture.detectChanges();
-
-    const textarea = fixture.debugElement.query(By.css('[data-testid="details-textarea"]'));
-    expect(textarea.attributes['ng-reflect-value']).toContain('Here are the details.');
   });
 
   it('should set ritName', () => {
@@ -121,6 +116,78 @@ describe('RitCreateComponent', () => {
     const initialLength = component.tags.length;
     component.removeTag(0);
     expect(component.tags.length).toBe(initialLength - 1);
+  });
+
+  it('should call createRit and show success toast on success', async () => {
+    const toast = { present: jasmine.createSpy() };
+    toastControllerSpy.create.and.returnValue(Promise.resolve(toast as any));
+
+    component.ritName = 'Test Rit';
+    component.details = 'Details';
+    component.tags = ['tag1'];
+
+    ritServiceSpy.createRit.and.returnValue(of({}));
+
+    const success = await component.createRit();
+
+    expect(success).toBeTrue();
+    expect(ritServiceSpy.createRit).toHaveBeenCalled();
+    expect(toastControllerSpy.create).toHaveBeenCalledWith(jasmine.objectContaining({ message: 'Rit created successfully!' }));
+    expect(toastControllerSpy.create).toHaveBeenCalledWith(jasmine.objectContaining({ color: 'success' }));
+    expect(toast.present).toHaveBeenCalled();
+  });
+
+  it('should call createRit and show error toast on unknown error', async () => {
+    const toast = { present: jasmine.createSpy() };
+    toastControllerSpy.create.and.returnValue(Promise.resolve(toast as any));
+
+    component.ritName = 'Test Rit';
+    component.details = 'Details';
+    component.tags = ['tag1'];
+
+    const mockErrorResponse = {
+      error: {
+        error: 'Unknown error'
+      }
+    };
+
+    ritServiceSpy.createRit.and.returnValue(throwError(() => mockErrorResponse));
+
+    const success = await component.createRit();
+
+    expect(success).toBeFalse();
+    expect(toastControllerSpy.create).toHaveBeenCalledWith(jasmine.objectContaining({ message: 'Unknown error', color: 'danger' }));
+    expect(toast.present).toHaveBeenCalled();
+  });
+
+  it('should call createRit and not show error toast on field validation errors', async () => {
+    const toast = { present: jasmine.createSpy() };
+    toastControllerSpy.create.and.returnValue(Promise.resolve(toast as any));
+
+    component.ritName = '';
+    component.details = 'Details';
+    component.tags = ['tag1'];
+
+    const mockValidationError = {
+      error: {
+        error: 'Validation failed',
+        fields: {
+          name: ['must not be empty'],
+          details: ['too short'],
+          tags: ['invalid tag']
+        }
+      }
+    };
+
+    ritServiceSpy.createRit.and.returnValue(throwError(() => mockValidationError));
+
+    const success = await component.createRit();
+
+    expect(success).toBeFalse();
+    expect(toast.present).not.toHaveBeenCalled();
+    expect(component.ritNameErrorMessage).toEqual('must not be empty');
+    expect(component.detailsErrorMessage).toEqual('too short');
+    expect(component.tagsErrorMessage).toEqual('invalid tag');
   });
 
 });

--- a/frontend/src/app/features/rit/rit-create/rit-create.component.ts
+++ b/frontend/src/app/features/rit/rit-create/rit-create.component.ts
@@ -1,18 +1,26 @@
 import { CommonModule } from '@angular/common';
-import { Component } from '@angular/core';
-import { IonInput } from '@ionic/angular/standalone';
+import { Component, Input, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { IonBackButton, IonInput } from '@ionic/angular/standalone';
 import { IonicStandaloneStandardImports } from '../../../shared/ionic-imports';
+import { RitService } from '../../../shared/services/rit.service';
 
 @Component({
   selector: 'app-rit-create',
   templateUrl: './rit-create.component.html',
   styleUrls: ['./rit-create.component.scss'],
   standalone: true,
-  imports: [CommonModule, ...IonicStandaloneStandardImports],
+  imports: [IonBackButton, CommonModule, ...IonicStandaloneStandardImports],
 })
-export class RitCreateComponent {
+export class RitCreateComponent implements OnInit {
 
-  constructor() { }
+  constructor(
+    private readonly ritService: RitService,
+    private readonly route: ActivatedRoute
+  ) { }
+
+  @Input() mode?: 'create' | 'edit' | 'view';
+  @Input() ritId: string | undefined;
 
   tags: string[] = []
   tagsErrorMessage?: string
@@ -22,6 +30,21 @@ export class RitCreateComponent {
   detailsErrorMessage?: string
 
   newTag?: string
+
+  ngOnInit(): void {
+    this.ritId = this.route.snapshot.paramMap.get('id') ?? undefined;
+
+    if (this.ritId) {
+      this.mode = 'view';
+      this.ritService.getRit(this.ritId).subscribe((rit) => {
+        this.ritName = rit.name;
+        this.details = rit.details ?? '';
+        this.tags = [...(rit.tags ?? [])];
+      });
+    } else {
+      this.mode = 'create';
+    }
+  }
 
   setRitName(event: any) {
     this.ritName = event.target.value

--- a/frontend/src/app/features/rit/rit-create/rit-create.component.ts
+++ b/frontend/src/app/features/rit/rit-create/rit-create.component.ts
@@ -49,7 +49,7 @@ export class RitCreateComponent implements ViewWillEnter {
 
   updateRit() {
     this.ritService.updateRit(this.buildRequest(), this.ritId!).subscribe({
-      next: (rit) => this.handleSuccess(rit, 'Rit updated sucessfully!'),
+      next: (rit) => this.handleSuccess(rit, 'Rit updated successfully!'),
       error: (err) => this.handleError(err),
     });
   }
@@ -58,12 +58,12 @@ export class RitCreateComponent implements ViewWillEnter {
     return new Promise((resolve, reject) => {
       this.ritService.createRit(this.buildRequest()).subscribe({
         next: (rit) => {
-          this.handleSuccess(rit, 'Rit created sucessfully!');
+          this.handleSuccess(rit, 'Rit created successfully!');
           resolve(true);
         },
         error: (err) => {
           this.handleError(err);
-          resolve(false); 
+          resolve(false);
         },
       });
     });

--- a/frontend/src/app/features/rit/rit-create/rit-create.component.ts
+++ b/frontend/src/app/features/rit/rit-create/rit-create.component.ts
@@ -1,11 +1,10 @@
 import { CommonModule } from '@angular/common';
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { IonBackButton, IonInput, ToastController, ViewWillEnter } from '@ionic/angular/standalone';
+import { Rit } from '../../../model/rit';
 import { IonicStandaloneStandardImports } from '../../../shared/ionic-imports';
 import { RitService } from '../../../shared/services/rit.service';
-import { Rit } from '../../../model/rit';
-import { Observable } from 'rxjs/internal/Observable';
 
 @Component({
   selector: 'app-rit-create',

--- a/frontend/src/app/features/rit/rit-create/rit-create.component.ts
+++ b/frontend/src/app/features/rit/rit-create/rit-create.component.ts
@@ -1,9 +1,10 @@
 import { CommonModule } from '@angular/common';
 import { Component, Input, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { IonBackButton, IonInput } from '@ionic/angular/standalone';
+import { IonBackButton, IonInput, ToastController, ViewWillEnter } from '@ionic/angular/standalone';
 import { IonicStandaloneStandardImports } from '../../../shared/ionic-imports';
 import { RitService } from '../../../shared/services/rit.service';
+import { Rit } from '../../../model/rit';
 
 @Component({
   selector: 'app-rit-create',
@@ -12,14 +13,15 @@ import { RitService } from '../../../shared/services/rit.service';
   standalone: true,
   imports: [IonBackButton, CommonModule, ...IonicStandaloneStandardImports],
 })
-export class RitCreateComponent implements OnInit {
+export class RitCreateComponent implements ViewWillEnter {
 
   constructor(
     private readonly ritService: RitService,
-    private readonly route: ActivatedRoute
+    private readonly route: ActivatedRoute,
+    private readonly toastController: ToastController,
   ) { }
 
-  @Input() mode?: 'create' | 'edit' | 'view';
+  mode?: 'create' | 'edit' | 'view';
   @Input() ritId: string | undefined;
 
   tags: string[] = []
@@ -31,7 +33,7 @@ export class RitCreateComponent implements OnInit {
 
   newTag?: string
 
-  ngOnInit(): void {
+  ionViewWillEnter(): void {
     this.ritId = this.route.snapshot.paramMap.get('id') ?? undefined;
 
     if (this.ritId) {
@@ -44,6 +46,75 @@ export class RitCreateComponent implements OnInit {
     } else {
       this.mode = 'create';
     }
+  }
+
+  confirmEdit() {
+    this.ritService.updateRit({
+      name: this.ritName,
+      details: this.details,
+      tags: this.tags
+    }, this.ritId!).subscribe({
+      next: (rit) => this.handleSuccess(rit),
+      error: (err) => this.handleError(err),
+    });
+  }
+
+  private handleSuccess(rit: Rit) {
+    this.ritName = rit.name;
+    this.details = rit.details ?? '';
+    this.tags = [...(rit.tags ?? [])];
+
+    this.showSuccessToast('Rit created updated!');
+    this.mode = 'view';
+  }
+
+  private handleError(err: any) {
+    const baseError = err.error?.error ?? 'Unknown error';
+    const fields = err.error?.fields;
+
+    if (fields) {
+      this.setFieldErrorMessages(fields);
+    } else {
+      this.showErrorToast(baseError);
+    }
+  }
+
+  async showSuccessToast(message: string) {
+    const toast = await this.toastController.create({
+      message: message,
+      duration: 2000,
+      position: 'top',
+      color: 'success',
+    });
+
+    await toast.present();
+  }
+
+  async showErrorToast(message: string) {
+    const toast = await this.toastController.create({
+      message: message,
+      duration: 4000,
+      position: 'top',
+      color: 'danger',
+    });
+
+    await toast.present();
+  }
+
+  public setFieldErrorMessages(fields: any) {
+    if (fields.name) {
+      this.ritNameErrorMessage = this.formatFieldError(fields.name);
+    }
+    if (fields.details) {
+      this.detailsErrorMessage = this.formatFieldError(fields.details);
+    }
+    if (fields.tags) {
+      this.tagsErrorMessage = this.formatFieldError(fields.tags);
+    }
+  }
+
+  private formatFieldError(fieldError: string | string[]): string {
+    return Array.isArray(fieldError) ? fieldError.join(', ') : `${fieldError}`;
   }
 
   setRitName(event: any) {

--- a/frontend/src/app/features/rit/rit-create/rit-create.component.ts
+++ b/frontend/src/app/features/rit/rit-create/rit-create.component.ts
@@ -35,7 +35,7 @@ export class RitCreateComponent implements ViewWillEnter {
   newTag?: string
 
   ionViewWillEnter(): void {
-    this.ritId = this.route.snapshot.paramMap.get('id') ?? undefined;
+    this.ritId = this.route.snapshot.paramMap.get('ritId') ?? undefined;
 
     if (this.ritId) {
       this.mode = 'view';
@@ -63,7 +63,7 @@ export class RitCreateComponent implements ViewWillEnter {
         },
         error: (err) => {
           this.handleError(err);
-          reject(false);
+          resolve(false); 
         },
       });
     });

--- a/frontend/src/app/features/rit/rit-list-item/rit-list-item.component.html
+++ b/frontend/src/app/features/rit/rit-list-item/rit-list-item.component.html
@@ -1,16 +1,15 @@
-
-  <div class="list-item-card ion-margin-bottom">
-    <ion-label class="content">
-      <h2 class="title">{{ rit.name }}</h2>
-      <div class="tags-container">
-        <ion-chip color="primary" *ngFor="let tag of rit.tags; let i = index">
-          <ion-icon name="pricetag-outline"></ion-icon>
-          <ion-label>{{ tag }}</ion-label>
-        </ion-chip>
-      </div>
-    </ion-label>
-    <!-- <ion-button size="default" class="ratingButton">
+<div class="list-item-card ion-margin-bottom" (click)="goToRit()">
+  <ion-label class="content">
+    <h2 class="title">{{ rit.name }}</h2>
+    <div class="tags-container">
+      <ion-chip color="primary" *ngFor="let tag of rit.tags; let i = index">
+        <ion-icon name="pricetag-outline"></ion-icon>
+        <ion-label>{{ tag }}</ion-label>
+      </ion-chip>
+    </div>
+  </ion-label>
+  <!-- <ion-button size="default" class="ratingButton">
       3
       <ion-icon name="star" slot="end"></ion-icon>
     </ion-button> -->
-  </div>
+</div>

--- a/frontend/src/app/features/rit/rit-list-item/rit-list-item.component.html
+++ b/frontend/src/app/features/rit/rit-list-item/rit-list-item.component.html
@@ -1,6 +1,6 @@
 
-  <div class="list-item-card ion-margin-bottom" (click)="goToRit()">
-    <ion-label class="content">
+  <div class="list-item-card ion-margin-bottom">
+    <ion-label (click)="navigateToRit()" class="content">
       <h2 class="title">{{ rit.name }}</h2>
       <div class="tags-container">
         <ion-chip color="primary" *ngFor="let tag of rit.tags; let i = index">

--- a/frontend/src/app/features/rit/rit-list-item/rit-list-item.component.html
+++ b/frontend/src/app/features/rit/rit-list-item/rit-list-item.component.html
@@ -1,6 +1,6 @@
 
   <div class="list-item-card ion-margin-bottom">
-    <ion-label (click)="navigateToRit()" class="content">
+    <ion-label (click)="navigateToRit()" (keydown.enter)="navigateToRit()" class="content">
       <h2 class="title">{{ rit.name }}</h2>
       <div class="tags-container">
         <ion-chip color="primary" *ngFor="let tag of rit.tags; let i = index">

--- a/frontend/src/app/features/rit/rit-list-item/rit-list-item.component.spec.ts
+++ b/frontend/src/app/features/rit/rit-list-item/rit-list-item.component.spec.ts
@@ -68,12 +68,12 @@ describe('RitListItemComponent', () => {
 
   it('should navigate to ratings with correct ID', () => {
     component.navigateToRatings();
-    expect(routerSpy.navigate).toHaveBeenCalledWith(['/ratings', testRit.id]);
+    expect(routerSpy.navigate).toHaveBeenCalledWith(['/rits/ratings', testRit.id]);
   });
 
   it('should navigate to rit view with correct ID', () => {
     component.navigateToRit();
-    expect(routerSpy.navigate).toHaveBeenCalledWith(['/rits/view/' + testRit.id]);
+    expect(routerSpy.navigate).toHaveBeenCalledWith(['/rits/view', testRit.id]);
   });
 
 

--- a/frontend/src/app/features/rit/rit-list-item/rit-list-item.component.spec.ts
+++ b/frontend/src/app/features/rit/rit-list-item/rit-list-item.component.spec.ts
@@ -3,10 +3,12 @@ import { IonicModule } from '@ionic/angular';
 import { RitListItemComponent } from './rit-list-item.component';
 import { Rit } from '../../../model/rit';
 import { By } from '@angular/platform-browser';
+import { Router } from '@angular/router';
 
 describe('RitListItemComponent', () => {
   let component: RitListItemComponent;
   let fixture: ComponentFixture<RitListItemComponent>;
+  let routerSpy: jasmine.SpyObj<Router> = jasmine.createSpyObj('Router', ['navigate']);
 
   const testRit: Rit = {
     id: '1',
@@ -19,6 +21,7 @@ describe('RitListItemComponent', () => {
 
     await TestBed.configureTestingModule({
       imports: [RitListItemComponent, IonicModule.forRoot()],
+      providers: [{ provide: Router, useValue: routerSpy }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(RitListItemComponent);
@@ -61,6 +64,16 @@ describe('RitListItemComponent', () => {
   it('should return 0 if no ratings are provided', () => {
     const latestRatingValue = component.calculateLatestRatingValue([]);
     expect(latestRatingValue).toBe(0);
+  });
+
+  it('should navigate to ratings with correct ID', () => {
+    component.navigateToRatings();
+    expect(routerSpy.navigate).toHaveBeenCalledWith(['/ratings', testRit.id]);
+  });
+
+  it('should navigate to rit view with correct ID', () => {
+    component.navigateToRit();
+    expect(routerSpy.navigate).toHaveBeenCalledWith(['/rits/view/' + testRit.id]);
   });
 
 

--- a/frontend/src/app/features/rit/rit-list-item/rit-list-item.component.ts
+++ b/frontend/src/app/features/rit/rit-list-item/rit-list-item.component.ts
@@ -40,7 +40,7 @@ export class RitListItemComponent {
     this.router.navigate(['/ratings', this.rit.id]);
   }
 
-  goToRit() {
+  navigateToRit(): void {
     this.router.navigate(['/rits/view/' + this.rit.id]);
   }
 

--- a/frontend/src/app/features/rit/rit-list-item/rit-list-item.component.ts
+++ b/frontend/src/app/features/rit/rit-list-item/rit-list-item.component.ts
@@ -1,7 +1,8 @@
-import { Component, Input } from '@angular/core';
-import { IonicStandaloneStandardImports } from '../../../shared/ionic-imports'; 
 import { CommonModule } from '@angular/common';
+import { Component, Input } from '@angular/core';
+import { Router } from '@angular/router';
 import { Rit } from '../../../model/rit';
+import { IonicStandaloneStandardImports } from '../../../shared/ionic-imports';
 
 @Component({
   selector: 'app-rit-list-item',
@@ -13,4 +14,12 @@ import { Rit } from '../../../model/rit';
 
 export class RitListItemComponent {
   @Input() rit!: Rit;
+
+  constructor(
+    private readonly router: Router,
+  ) { }
+
+  goToRit() {
+    this.router.navigate(['/rits/view/' + this.rit.id]);
+  }
 }

--- a/frontend/src/app/features/rit/rit-list-item/rit-list-item.component.ts
+++ b/frontend/src/app/features/rit/rit-list-item/rit-list-item.component.ts
@@ -37,11 +37,11 @@ export class RitListItemComponent {
   }
 
   navigateToRatings(): void {
-    this.router.navigate(['/ratings', this.rit.id]);
+    this.router.navigate(['/rits/ratings', this.rit.id]);
   }
 
   navigateToRit(): void {
-    this.router.navigate(['/rits/view/' + this.rit.id]);
+    this.router.navigate(['/rits/view', this.rit.id]);
   }
 
 }

--- a/frontend/src/app/features/tabs/home/home.component.html
+++ b/frontend/src/app/features/tabs/home/home.component.html
@@ -54,7 +54,7 @@
         </ion-toolbar>
       </ion-header>
 
-      <ion-content class="ion-padding">
+      <ion-content>
         <app-rit-create #ritCreate></app-rit-create>
       </ion-content>
     </ng-template>

--- a/frontend/src/app/features/tabs/home/home.component.html
+++ b/frontend/src/app/features/tabs/home/home.component.html
@@ -52,7 +52,7 @@
       </ion-header>
 
       <ion-content class="ion-padding">
-        <app-rit-create #ritCreate [mode]="'create'"></app-rit-create>
+        <app-rit-create #ritCreate></app-rit-create>
       </ion-content>
     </ng-template>
   </ion-modal>

--- a/frontend/src/app/features/tabs/home/home.component.html
+++ b/frontend/src/app/features/tabs/home/home.component.html
@@ -32,7 +32,7 @@
     </ion-fab-list>
   </ion-fab>
 
-  <ion-modal #modal trigger="open-modal" [canDismiss]="canDismiss" [initialBreakpoint]="0.8" [breakpoints]="[0, 0.8]">
+  <ion-modal #modal trigger="open-modal" [canDismiss]="canDismiss" [presentingElement]="presentingElement">
     <ng-template>
       <ion-header>
         <ion-toolbar>
@@ -52,7 +52,7 @@
       </ion-header>
 
       <ion-content class="ion-padding">
-        <app-rit-create #ritCreate></app-rit-create>
+        <app-rit-create #ritCreate [mode]="'create'"></app-rit-create>
       </ion-content>
     </ng-template>
   </ion-modal>

--- a/frontend/src/app/features/tabs/home/home.component.ts
+++ b/frontend/src/app/features/tabs/home/home.component.ts
@@ -117,35 +117,9 @@ export class HomeComponent implements ViewWillEnter {
   };
 
   async confirm() {
-    const request = this.buildRequest();
-
-    this.ritService.createRit(request).subscribe({
-      next: () => this.handleRitCreateSuccess(),
-      error: (err) => this.handleRitCreateError(err),
-    });
-  }
-
-  private buildRequest(): Rit {
-    return {
-      name: this.ritCreateComponent.ritName,
-      details: this.ritCreateComponent.details,
-      tags: this.ritCreateComponent.tags ?? [],
-    };
-  }
-
-  private handleRitCreateSuccess() {
-    this.showSuccessToast('Rit created successfully!');
-    this.modal.dismiss(null, 'confirm');
-  }
-
-  private handleRitCreateError(err: any) {
-    const baseError = err.error?.error ?? 'Unknown error';
-    const fields = err.error?.fields;
-
-    if (fields) {
-      this.ritCreateComponent.setFieldErrorMessages(fields);
-    } else {
-      this.showErrorToast(baseError);
+    const success = await this.ritCreateComponent.createRit();
+    if (success) {
+      this.modal.dismiss(null, 'confirm');
     }
   }
 
@@ -159,7 +133,6 @@ export class HomeComponent implements ViewWillEnter {
     });
   }
 
-
   private handleLoadRitsError(err: any) {
     const baseError = err.error?.error ?? 'Unknown error';
     this.showErrorToast(baseError);
@@ -172,6 +145,7 @@ export class HomeComponent implements ViewWillEnter {
   goToRitsTab() {
     this.router.navigate(['/rits']);
   }
+
   handleRefresh(event: CustomEvent) {
     this.ritService.triggerRitsReload().subscribe({
       next: () => {

--- a/frontend/src/app/features/tabs/home/home.component.ts
+++ b/frontend/src/app/features/tabs/home/home.component.ts
@@ -46,7 +46,7 @@ export class HomeComponent implements ViewWillEnter {
   ) { }
 
   ionViewWillEnter() {
-    this.presentingElement = document.querySelector('.ion-page');
+    this.presentingElement = document.querySelector('ion-page');
     this.isLoggedIn$ = this.userService.isLoggedIn();
     this.ritSubscription = this.ritService.getRits().subscribe({
       next: (data) => {

--- a/frontend/src/app/features/tabs/home/home.component.ts
+++ b/frontend/src/app/features/tabs/home/home.component.ts
@@ -20,7 +20,7 @@ import { Router } from '@angular/router';
     ...IonicStandaloneStandardImports,
     RitCreateComponent,
     RitListItemComponent
-],
+  ],
 })
 export class HomeComponent implements ViewWillEnter {
 
@@ -123,26 +123,10 @@ export class HomeComponent implements ViewWillEnter {
     const fields = err.error?.fields;
 
     if (fields) {
-      this.setFieldErrorMessages(fields);
+      this.ritCreateComponent.setFieldErrorMessages(fields);
     } else {
       this.showErrorToast(baseError);
     }
-  }
-
-  private setFieldErrorMessages(fields: any) {
-    if (fields.name) {
-      this.ritCreateComponent.ritNameErrorMessage = this.formatFieldError(fields.name);
-    }
-    if (fields.details) {
-      this.ritCreateComponent.detailsErrorMessage = this.formatFieldError(fields.details);
-    }
-    if (fields.tags) {
-      this.ritCreateComponent.tagsErrorMessage = this.formatFieldError(fields.tags);
-    }
-  }
-
-  private formatFieldError(fieldError: string | string[]): string {
-    return Array.isArray(fieldError) ? fieldError.join(', ') : `${fieldError}`;
   }
 
   private loadRits(): void {

--- a/frontend/src/app/features/tabs/home/home.component.ts
+++ b/frontend/src/app/features/tabs/home/home.component.ts
@@ -117,8 +117,7 @@ export class HomeComponent implements ViewWillEnter {
   };
 
   async confirm() {
-    const success = await this.ritCreateComponent.createRit();
-    if (success) {
+    if (await this.ritCreateComponent.createRit()) {
       this.modal.dismiss(null, 'confirm');
     }
   }

--- a/frontend/src/app/shared/ionic-imports.ts
+++ b/frontend/src/app/shared/ionic-imports.ts
@@ -1,5 +1,4 @@
 import {
-  IonToast,
   IonBadge,
   IonButton,
   IonButtons,
@@ -23,6 +22,8 @@ import {
   IonLabel,
   IonList,
   IonModal,
+  IonNav,
+  IonNote,
   IonRippleEffect,
   IonRouterOutlet,
   IonRow,
@@ -37,11 +38,12 @@ import {
   IonTextarea,
   IonThumbnail,
   IonTitle,
+  IonToast,
   IonToolbar,
-  IonNote,
 } from '@ionic/angular/standalone';
 
 export const IonicStandaloneStandardImports = [
+  IonNav,
   IonToast,
   IonCardSubtitle,
   IonRippleEffect,

--- a/frontend/src/app/shared/ionic-imports.ts
+++ b/frontend/src/app/shared/ionic-imports.ts
@@ -24,9 +24,12 @@ import {
   IonModal,
   IonNav,
   IonNote,
+  IonRefresher,
+  IonRefresherContent,
   IonRippleEffect,
   IonRouterOutlet,
   IonRow,
+  IonSearchbar,
   IonSegment,
   IonSegmentButton,
   IonSegmentContent,
@@ -40,10 +43,6 @@ import {
   IonTitle,
   IonToast,
   IonToolbar,
-  IonNote,
-  IonSearchbar,
-  IonRefresher,
-  IonRefresherContent,
 } from '@ionic/angular/standalone';
 
 export const IonicStandaloneStandardImports = [

--- a/frontend/src/app/shared/services/api.service.spec.ts
+++ b/frontend/src/app/shared/services/api.service.spec.ts
@@ -61,6 +61,21 @@ describe('ApiService', () => {
     req.flush(mockResponse);
   });
 
+  it('should perform a PUT request with the correct headers and body', () => {
+    const mockBody = { key: 'value' };
+    const mockResponse = { success: true };
+
+    service.put('/test/12', mockBody).pipe(first()).subscribe(response => {
+      expect(response).toEqual(mockResponse);
+    });
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/test/12`);
+    expect(req.request.method).toBe('PUT');
+    expect(req.request.headers.get('Authorization')).toBe('Bearer token');
+    expect(req.request.body).toEqual(mockBody);
+    req.flush(mockResponse);
+  });
+
   it('should call AuthService.logout on 403 error for GET request', () => {
     const authServiceSpy = TestBed.inject(AuthService) as jasmine.SpyObj<AuthService>;
     service.get('/test').pipe(first()).subscribe({

--- a/frontend/src/app/shared/services/api.service.ts
+++ b/frontend/src/app/shared/services/api.service.ts
@@ -35,6 +35,17 @@ export class ApiService {
     );
   }
 
+  put(path: string, body: Object): Observable<any> {
+    return this.http.put<any>(this.baseEndpoint + path, body, this.addTokenHeader()).pipe(
+      catchError(error => {
+        if (error.status === 403) {
+          this.authService.logout();
+        }
+        throw error;
+      })
+    );
+  }
+
   addTokenHeader() {
     if (this.authService.getToken() != null) {
       return { headers: { Authorization: `Bearer ${this.authService.getToken()}` } };

--- a/frontend/src/app/shared/services/rit.service.spec.ts
+++ b/frontend/src/app/shared/services/rit.service.spec.ts
@@ -1,10 +1,10 @@
 import { TestBed } from '@angular/core/testing';
-import { provideMockApiService, provideMockAuthService } from '../test-util/test-util';
-import { RitService } from './rit.service';
-import { ApiService } from './api.service';
-import { first, of, skip, throwError, Subject } from 'rxjs';
+import { first, of, skip, Subject, throwError } from 'rxjs';
 import { Rit } from '../../model/rit';
+import { provideMockApiService, provideMockAuthService } from '../test-util/test-util';
+import { ApiService } from './api.service';
 import { AuthService } from './auth.service';
+import { RitService } from './rit.service';
 
 describe('RitService', () => {
 
@@ -237,5 +237,39 @@ describe('RitService', () => {
     service.triggerRitsReload().subscribe();
   }
   );
+
+  it('should update an existing rit', (done) => {
+    let service = TestBed.inject(RitService);
+    const apiServiceSpy = (TestBed.inject(ApiService)) as jasmine.SpyObj<ApiService>;
+
+    const rit: Rit = { name: 'updatedRit', details: 'updated details', tags: ['tag1'] };
+    const ritId = '123';
+
+    apiServiceSpy.put.and.returnValue(of(rit));
+
+    service.updateRit(rit, ritId).subscribe(response => {
+      expect(response).toEqual(rit);
+      expect(apiServiceSpy.put).toHaveBeenCalledWith('/rit/update/123', rit);
+      expect(apiServiceSpy.put).toHaveBeenCalledTimes(1);
+      done();
+    });
+  });
+
+  it('should get a specific rit by ID from API', (done) => {
+    let service = TestBed.inject(RitService);
+    const apiServiceSpy = (TestBed.inject(ApiService)) as jasmine.SpyObj<ApiService>;
+
+    const ritId = 'abc';
+    const expectedRit: Rit = { id: ritId, name: 'fetchedRit', details: 'details', tags: ['tag1'] };
+
+    apiServiceSpy.get.and.returnValue(of(expectedRit));
+
+    service.getRit(ritId).subscribe(response => {
+      expect(response).toEqual(expectedRit);
+      expect(apiServiceSpy.get).toHaveBeenCalledWith('/rit/read/abc');
+      expect(apiServiceSpy.get).toHaveBeenCalledTimes(1);
+      done();
+    });
+  });
 
 });

--- a/frontend/src/app/shared/services/rit.service.ts
+++ b/frontend/src/app/shared/services/rit.service.ts
@@ -17,4 +17,8 @@ export class RitService {
   getAllRits(): Observable<Rit[]> {
     return this.apiService.get('/rit/rits');
   }
+
+  getRit(ritId: string): Observable<Rit> {
+    return this.apiService.get('/rit/read/' + ritId);
+  }
 }

--- a/frontend/src/app/shared/services/rit.service.ts
+++ b/frontend/src/app/shared/services/rit.service.ts
@@ -29,8 +29,16 @@ export class RitService {
     )
   }
 
+  updateRit(rit: Rit, ritId: string): Observable<Rit> {
+    return this.apiService.put('/rit/update/' + ritId, rit);
+  }
+
   getRits(): Observable<Rit[]> {
     return this.rits.asObservable();
+  }
+
+  getRit(ritId: string): Observable<Rit> {
+    return this.apiService.get('/rit/read/' + ritId);
   }
 
   getRitById(id: string): Observable<Rit|null> {
@@ -61,12 +69,5 @@ export class RitService {
       })
     );
   }
-
-  updateRit(rit: Rit, ritId: string): Observable<Rit> {
-    return this.apiService.put('/rit/update/' + ritId, rit);
-  }
-
-  getRit(ritId: string): Observable<Rit> {
-    return this.apiService.get('/rit/read/' + ritId);
-  }
+  
 }

--- a/frontend/src/app/shared/services/rit.service.ts
+++ b/frontend/src/app/shared/services/rit.service.ts
@@ -22,11 +22,7 @@ export class RitService {
   }
 
   createRit(rit: Rit): Observable<any> {
-    return this.apiService.post('/rit/create', rit).pipe(
-      tap(() => {
-        this.triggerRitsReload().subscribe({});
-      })
-    )
+    return this.apiService.post('/rit/create', rit);
   }
 
   updateRit(rit: Rit, ritId: string): Observable<Rit> {

--- a/frontend/src/app/shared/services/rit.service.ts
+++ b/frontend/src/app/shared/services/rit.service.ts
@@ -14,6 +14,10 @@ export class RitService {
     return this.apiService.post('/rit/create', rit);
   }
 
+  updateRit(rit: Rit, ritId: string): Observable<Rit> {
+    return this.apiService.put('/rit/update/' + ritId, rit);
+  }
+
   getAllRits(): Observable<Rit[]> {
     return this.apiService.get('/rit/rits');
   }

--- a/frontend/src/app/shared/test-util/test-util.ts
+++ b/frontend/src/app/shared/test-util/test-util.ts
@@ -1,10 +1,10 @@
 import { of } from "rxjs";
-import { AuthService } from "../services/auth.service";
 import { ApiService } from "../services/api.service";
+import { AuthService } from "../services/auth.service";
 
 export function provideMockAuthService(authStatus: boolean): any {
     const authServiceSpy = jasmine.createSpyObj('AuthService', ['isAuthenticated', 'getAuthenticationStatusObservable', 'login', 'logout', 'getToken']);
-    authServiceSpy.getToken.and.returnValue(authStatus? 'token' : null);
+    authServiceSpy.getToken.and.returnValue(authStatus ? 'token' : null);
     authServiceSpy.isAuthenticated.and.returnValue(authStatus);
     authServiceSpy.getAuthenticationStatusObservable.and.returnValue(of(authStatus));
     authServiceSpy.login.and.returnValue(of({}));
@@ -16,9 +16,10 @@ export function provideMockAuthService(authStatus: boolean): any {
 }
 
 export function provideMockApiService(): any {
-    const apiServiceSpy = jasmine.createSpyObj('ApiService', ['get', 'post']);
+    const apiServiceSpy = jasmine.createSpyObj('ApiService', ['get', 'post', 'put']);
     apiServiceSpy.get.and.returnValue(of({}));
     apiServiceSpy.post.and.returnValue(of({}));
+    apiServiceSpy.put.and.returnValue(of({}));
 
     return {
         provide: ApiService,

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -4,7 +4,7 @@ import { RouteReuseStrategy, provideRouter } from '@angular/router';
 import { IonicRouteStrategy, provideIonicAngular } from '@ionic/angular/standalone';
 import { defineCustomElements } from '@ionic/pwa-elements/loader';
 import { addIcons } from 'ionicons';
-import { addOutline, chevronForward, close, home, homeOutline, logInOutline, personOutline, pricetagOutline, star, starOutline } from 'ionicons/icons';
+import { addOutline, chevronForward, close, createOutline, home, homeOutline, logInOutline, personOutline, pricetagOutline, star, starOutline } from 'ionicons/icons';
 import { AppComponent } from './app/app.component';
 import { routes } from './app/app.routes';
 
@@ -22,13 +22,14 @@ bootstrapApplication(AppComponent, {
 
 addIcons({
   home,
-  homeOutline, 
+  homeOutline,
   personOutline,
   addOutline,
   pricetagOutline,
   star,
-  starOutline, 
+  starOutline,
   close,
   logInOutline,
-  chevronForward
+  chevronForward,
+  createOutline
 });


### PR DESCRIPTION
Anmerkung für Reviewer (@averel10):

Wenn ich die Route in das TabMenu einbinde, funktioniert der built in Back-Button nur mit dem `defaultHref="/rits"` im rit-create.component.html:4. Würde man den Component als eigene Route definieren, funktioniert der built-in Back Button korrekt, dafür wird das TebMenu nicht eingeblendet. Allenfalls gäbe es noch eine dritte Möglichkeiten mit einem custom Button, dann müsste man halt einfach immer irgendwo mitgeben von welcher Page man kommt.

Gerne angeben was du am besten findest, kann ich dann morgen / am Mittwoch ggf. anpassen.