### PR TITLE
237 refactoring ux weiterleitungen verbessern user flow verbessern

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "frontend",
       "version": "0.0.0",
-      "hasInstallScript": true,
       "dependencies": {
         "@angcap/git-info": "^1.1.2",
         "@angular/animations": "^19.2.7",

--- a/frontend/src/app/app.routes.spec.ts
+++ b/frontend/src/app/app.routes.spec.ts
@@ -44,112 +44,112 @@ describe('App Routing', () => {
     const fixture = TestBed.createComponent(TestHostComponent);
     fixture.detectChanges();
 
-    await router.navigate(['/profile']);
+    await router.navigate(['/tabs/profile']);
     fixture.detectChanges();
 
     expect(location.path()).toBe('');
   }));
 
-  it('should navigate to /profile if authenticated', waitForAsync(async () => {
+  it('should navigate to /tabs/profile if authenticated', waitForAsync(async () => {
     const authServiceSpy = TestBed.inject(AuthService) as jasmine.SpyObj<AuthService>;
     authServiceSpy.isAuthenticated.and.returnValue(true);
     const fixture = TestBed.createComponent(TestHostComponent);
     fixture.detectChanges();
 
-    await router.navigate(['/profile']);
+    await router.navigate(['/tabs/profile']);
     fixture.detectChanges();
 
-    expect(location.path()).toBe('/profile');
+    expect(location.path()).toBe('/tabs/profile');
   }));
 
-  it('should navigate to /home', waitForAsync(async () => {
+  it('should navigate to /tabs/home', waitForAsync(async () => {
     const fixture = TestBed.createComponent(TestHostComponent);
     fixture.detectChanges();
 
-    await router.navigate(['/home']);
+    await router.navigate(['/tabs/home']);
     fixture.detectChanges();
 
-    expect(location.path()).toBe('/home');
+    expect(location.path()).toBe('/tabs/home');
   }));
 
-  it('should navigate to /user/mail-confirmation', waitForAsync(async () => {
+  it('should navigate to /tabs/user/mail-confirmation', waitForAsync(async () => {
     const fixture = TestBed.createComponent(TestHostComponent);
     fixture.detectChanges();
 
-    await router.navigate(['/user/mail-confirmation']);
+    await router.navigate(['/tabs/user/mail-confirmation']);
     fixture.detectChanges();
 
-    expect(location.path()).toBe('/user/mail-confirmation');
+    expect(location.path()).toBe('/tabs/user/mail-confirmation');
   }
   ));
 
-  it('should navigate to /login', waitForAsync(async () => {
+  it('should navigate to /tabs/login', waitForAsync(async () => {
     const fixture = TestBed.createComponent(TestHostComponent);
     fixture.detectChanges();
 
-    await router.navigate(['/login']);
+    await router.navigate(['/tabs/login']);
     fixture.detectChanges();
 
-    expect(location.path()).toBe('/login');
+    expect(location.path()).toBe('/tabs/login');
   }));
 
-  it('should navigate to /register', waitForAsync(async () => {
+  it('should navigate to /tabs/register', waitForAsync(async () => {
     const fixture = TestBed.createComponent(TestHostComponent);
     fixture.detectChanges();
 
-    await router.navigate(['/register']);
+    await router.navigate(['/tabs/register']);
     fixture.detectChanges();
 
-    expect(location.path()).toBe('/register');
+    expect(location.path()).toBe('/tabs/register');
   }));
 
-  it('should navigate "" to /home', waitForAsync(async () => {
+  it('should navigate "" to /tabs/home', waitForAsync(async () => {
     const fixture = TestBed.createComponent(TestHostComponent);
     fixture.detectChanges();
 
     await router.navigate(['/']);
     fixture.detectChanges();
 
-    expect(location.path()).toBe('/home');
+    expect(location.path()).toBe('/tabs/home');
   }));
 
-  it('should navigate to /rits', waitForAsync(async () => {
+  it('should navigate to /tabs/rits', waitForAsync(async () => {
     const fixture = TestBed.createComponent(TestHostComponent);
     fixture.detectChanges();
 
-    await router.navigate(['/rits']);
+    await router.navigate(['/tabs/rits']);
     fixture.detectChanges();
 
-    expect(location.path()).toBe('/rits');
+    expect(location.path()).toBe('/tabs/rits');
   }));
 
-  it('should navigate to /rits/view/12', waitForAsync(async () => {
+  it('should navigate to /tabs/rits/view/12', waitForAsync(async () => {
     const fixture = TestBed.createComponent(TestHostComponent);
     fixture.detectChanges();
 
-    await router.navigate(['/rits/view/12']);
+    await router.navigate(['/tabs/rits/view/12']);
     fixture.detectChanges();
 
-    expect(location.path()).toBe('/rits/view/12');
+    expect(location.path()).toBe('/tabs/rits/view/12');
   }));
 
-  it('should navigate to /rits/ratings/12', waitForAsync(async () => {
+  it('should navigate to /tabs/rits/ratings/12', waitForAsync(async () => {
     const fixture = TestBed.createComponent(TestHostComponent);
     fixture.detectChanges();
 
-    await router.navigate(['/rits/ratings/12']);
+    await router.navigate(['/tabs/rits/ratings/12']);
     fixture.detectChanges();
 
-    expect(location.path()).toBe('/rits/ratings/12');
+    expect(location.path()).toBe('/tabs/rits/ratings/12');
   }));
 
-  it('should navigate to /build-info', waitForAsync(async () => {
+  it('should navigate to /tabs/build-info', waitForAsync(async () => {
     const fixture = TestBed.createComponent(TestHostComponent);
     fixture.detectChanges();
 
     await router.navigate(['/build-info']);
     fixture.detectChanges();
 
-    expect(location.path()).toBe('/build-info');
+    expect(location.path()).toBe('/tabs/build-info');
   }));
 });

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -12,6 +12,18 @@ export const routes: Routes = [
         loadComponent: () => import('./features/tabs/home/home.component').then((m) => m.HomeComponent),
       },
       {
+        path: 'home/rits/view/:ritId',
+        loadComponent: () => import('./features/rit/rit-create/rit-create.component').then(m => m.RitCreateComponent),
+        canActivate: [AuthGuard],
+        data: { mode: 'view' }
+      },
+      {
+        path: 'home/rits/ratings/:ritId',
+        pathMatch: 'full',
+        loadComponent: () => import('./features/rating/all-ratings/all-ratings.component').then((m) => m.AllRatingsComponent),
+        canActivate: [AuthGuard],
+      },
+      {
         path: 'rits',
         loadComponent: () => import('./features/tabs/all-rits/all-rits.component').then((m) => m.AllRitsComponent),
         canActivate: [AuthGuard],

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -4,73 +4,101 @@ import { AuthGuard } from './shared/guards/auth.guard';
 
 export const routes: Routes = [
   {
-    path: '',
+    path: 'tabs',
     component: TabMenuComponent,
     children: [
       {
         path: 'home',
-        loadComponent: () => import('./features/tabs/home/home.component').then((m) => m.HomeComponent),
-      },
-      {
-        path: 'home/rits/view/:ritId',
-        loadComponent: () => import('./features/rit/rit-create/rit-create.component').then(m => m.RitCreateComponent),
-        canActivate: [AuthGuard],
-        data: { mode: 'view' }
-      },
-      {
-        path: 'home/rits/ratings/:ritId',
-        pathMatch: 'full',
-        loadComponent: () => import('./features/rating/all-ratings/all-ratings.component').then((m) => m.AllRatingsComponent),
-        canActivate: [AuthGuard],
+        children: [
+          {
+            path: '',
+            loadComponent: () =>
+              import('./features/tabs/home/home.component').then((m) => m.HomeComponent),
+          },
+          {
+            path: 'rits/view/:ritId',
+            loadComponent: () =>
+              import('./features/rit/rit-create/rit-create.component').then((m) => m.RitCreateComponent),
+            canActivate: [AuthGuard],
+            data: { mode: 'view' },
+          },
+          {
+            path: 'rits/ratings/:ritId',
+            loadComponent: () =>
+              import('./features/rating/all-ratings/all-ratings.component').then((m) => m.AllRatingsComponent),
+            canActivate: [AuthGuard],
+          },
+        ],
       },
       {
         path: 'rits',
-        loadComponent: () => import('./features/tabs/all-rits/all-rits.component').then((m) => m.AllRitsComponent),
-        canActivate: [AuthGuard],
-      },
-      {
-        path: 'rits/view/:ritId',
-        loadComponent: () => import('./features/rit/rit-create/rit-create.component').then(m => m.RitCreateComponent),
-        canActivate: [AuthGuard],
-        data: { mode: 'view' }
-      },
-      {
-        path: 'rits/ratings/:ritId',
-        pathMatch: 'full',
-        loadComponent: () => import('./features/rating/all-ratings/all-ratings.component').then((m) => m.AllRatingsComponent),
-        canActivate: [AuthGuard],
+        children: [
+          {
+            path: '',
+            loadComponent: () =>
+              import('./features/tabs/all-rits/all-rits.component').then((m) => m.AllRitsComponent),
+            canActivate: [AuthGuard],
+          },
+          {
+            path: 'view/:ritId',
+            loadComponent: () =>
+              import('./features/rit/rit-create/rit-create.component').then((m) => m.RitCreateComponent),
+            canActivate: [AuthGuard],
+            data: { mode: 'view' },
+          },
+          {
+            path: 'ratings/:ritId',
+            loadComponent: () =>
+              import('./features/rating/all-ratings/all-ratings.component').then((m) => m.AllRatingsComponent),
+            canActivate: [AuthGuard],
+          },
+        ],
       },
       {
         path: 'login',
-        loadComponent: () => import('./features/tabs/login/login.component').then((m) => m.LoginComponent),
+        loadComponent: () =>
+          import('./features/tabs/login/login.component').then((m) => m.LoginComponent),
       },
       {
         path: 'register',
-        loadComponent: () => import('./features/tabs/register/register.component').then((m) => m.RegisterComponent),
+        loadComponent: () =>
+          import('./features/tabs/register/register.component').then((m) => m.RegisterComponent),
       },
       {
         path: 'user/mail-confirmation',
-        loadComponent: () => import('./features/tabs/mail-confirmation/mail-confirmation.component').then((m) => m.MailConfirmationComponent),
+        loadComponent: () =>
+          import('./features/tabs/mail-confirmation/mail-confirmation.component').then(
+            (m) => m.MailConfirmationComponent
+          ),
       },
       {
         path: 'profile',
-        loadComponent: () => import('./features/tabs/profile/profile.component').then((m) => m.ProfileComponent),
+        loadComponent: () =>
+          import('./features/tabs/profile/profile.component').then((m) => m.ProfileComponent),
         canActivate: [AuthGuard],
       },
       {
         path: 'build-info',
-        loadComponent: () => import('./features/tabs/app-build-info/app-build-info.component').then((m) => m.AppBuildInfoComponent),
+        loadComponent: () =>
+          import('./features/tabs/app-build-info/app-build-info.component').then(
+            (m) => m.AppBuildInfoComponent
+          ),
       },
       {
         path: '',
-        redirectTo: '/home',
+        redirectTo: 'home',
         pathMatch: 'full',
-      },
+      }
     ],
   },
   {
+    path: 'build-info',
+    redirectTo: '/tabs/build-info',
+    pathMatch: 'full',
+  },
+  {
     path: '',
-    redirectTo: '/home',
+    redirectTo: '/tabs/home',
     pathMatch: 'full',
   },
 ];

--- a/frontend/src/app/features/modal/fab-integration/fab-integration.component.html
+++ b/frontend/src/app/features/modal/fab-integration/fab-integration.component.html
@@ -1,5 +1,3 @@
 <app-fab [buttons]="buttons"></app-fab>
-<app-modal-view [content]="ritCreate" #ritCreateModal><app-rit-create #ritCreate></app-rit-create></app-modal-view>
-<app-modal-view *ngIf="currentRit != null"  [content]="rate" #rateModal><app-rate [rit]="rit" #rate></app-rate></app-modal-view>
-
-
+<app-modal-view [title]="'Create Rit'" [content]="ritCreate" #ritCreateModal><app-rit-create #ritCreate></app-rit-create></app-modal-view>
+<app-modal-view *ngIf="currentRit != null"  [title]="'Create Rating'" [content]="rate" #rateModal><app-rate [rit]="rit" #rate></app-rate></app-modal-view>

--- a/frontend/src/app/features/modal/fab-integration/fab-integration.component.spec.ts
+++ b/frontend/src/app/features/modal/fab-integration/fab-integration.component.spec.ts
@@ -37,12 +37,6 @@ describe('FabIntegrationComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should add rating Button if currentRit is not null', () => {
-    component.currentRit = { id: '1', name: 'Test Rit' } as any;
-    component.updateButtons();
-    expect(component.buttons.length).toBe(2);
-  }
-  );
   it('should not add rating Button if currentRit is null', () => {
     component.currentRit = null;
     component.updateButtons();

--- a/frontend/src/app/features/modal/fab-integration/fab-integration.component.spec.ts
+++ b/frontend/src/app/features/modal/fab-integration/fab-integration.component.spec.ts
@@ -42,4 +42,10 @@ describe('FabIntegrationComponent', () => {
     component.updateButtons();
     expect(component.buttons.length).toBe(1);
   });
+
+  it('should add rating Button if currentRit is not null', () => {
+    component.currentRit = {id: '1', name: 'Test Rit', details: 'Some details', tags: ['tag1', 'tag2']};
+    component.updateButtons();
+    expect(component.buttons.length).toBe(1);
+  });
 });

--- a/frontend/src/app/features/modal/fab-integration/fab-integration.component.ts
+++ b/frontend/src/app/features/modal/fab-integration/fab-integration.component.ts
@@ -15,16 +15,16 @@ import { RateComponent } from '../../rit/rate/rate.component';
   imports: [CommonModule, ...IonicStandaloneStandardImports, FabComponent, ModalViewComponent, RitCreateComponent, RateComponent],
   standalone: true,
 })
-export class FabIntegrationComponent  implements OnInit {
-  @Input() rit!: Observable<Rit|null> | null;
+export class FabIntegrationComponent implements OnInit {
+  @Input() rit!: Observable<Rit | null> | null;
   private ritSubscription: any;
-  currentRit: Rit|null = null;
+  currentRit: Rit | null = null;
   @ViewChild(FabComponent) fabComponent!: FabComponent;
   @ViewChild("ritCreateModal") ritCreateModalComponent!: ModalViewComponent;
   @ViewChild("rateModal") ratingCreateModalComponent!: ModalViewComponent;
 
   buttons: FabButton[] = [];
-  
+
   ngOnInit() {
     this.updateButtons();
     this.ritSubscription = this.rit?.subscribe((data) => {
@@ -40,17 +40,20 @@ export class FabIntegrationComponent  implements OnInit {
   }
 
   updateButtons() {
-    this.buttons = [
-      {
-        icon: 'add-outline',
-        action: () => this.ritCreateModalComponent.modal.present(),
-      },
-    ];
-    if (this.currentRit) {
-      this.buttons.push({
-        icon: 'star-outline',
-        action: () => this.ratingCreateModalComponent.modal.present(),
-      });
+    if (!this.currentRit) {
+      this.buttons = [
+        {
+          icon: 'add-outline',
+          action: () => this.ritCreateModalComponent.modal.present(),
+        },
+      ];
+    } else {
+      this.buttons = [
+        {
+          icon: 'star-outline',
+          action: () => this.ratingCreateModalComponent.modal.present()
+        },
+      ];
     }
   }
 

--- a/frontend/src/app/features/modal/modal-view/modal-view.component.html
+++ b/frontend/src/app/features/modal/modal-view/modal-view.component.html
@@ -7,7 +7,7 @@
             Cancel
           </ion-button>
         </ion-buttons>
-        <ion-title>Rit Create</ion-title>
+        <ion-title>{{title}}</ion-title>
         <ion-buttons slot="end">
           <ion-button [disabled]="isDisabled" (click)="confirm()" (keydown.enter)="confirm()" [strong]="true">
             Confirm

--- a/frontend/src/app/features/modal/modal-view/modal-view.component.html
+++ b/frontend/src/app/features/modal/modal-view/modal-view.component.html
@@ -1,4 +1,4 @@
-<ion-modal #modal trigger="open-modal" [canDismiss]="canDismiss" [presentingElement]="presentingElement">
+<ion-modal [canDismiss]="canDismiss" [presentingElement]="presentingElement">
   <ng-template>
     <ion-header>
       <ion-toolbar>

--- a/frontend/src/app/features/modal/modal-view/modal-view.component.html
+++ b/frontend/src/app/features/modal/modal-view/modal-view.component.html
@@ -1,4 +1,4 @@
-<ion-modal [canDismiss]="canDismiss" [presentingElement]="presentingElement">
+<ion-modal #modal trigger="open-modal" [canDismiss]="canDismiss" [presentingElement]="presentingElement">
   <ng-template>
     <ion-header>
       <ion-toolbar>
@@ -9,8 +9,7 @@
         </ion-buttons>
         <ion-title>Rit Create</ion-title>
         <ion-buttons slot="end">
-          <ion-button [disabled]="isDisabled" (click)="confirm()" (keydown.enter)="confirm()"
-            [strong]="true">
+          <ion-button [disabled]="isDisabled" (click)="confirm()" (keydown.enter)="confirm()" [strong]="true">
             Confirm
           </ion-button>
         </ion-buttons>

--- a/frontend/src/app/features/modal/modal-view/modal-view.component.ts
+++ b/frontend/src/app/features/modal/modal-view/modal-view.component.ts
@@ -21,7 +21,7 @@ export class ModalViewComponent implements OnInit {
     private readonly actionSheetCtrl: ActionSheetController) { }
 
   ngOnInit() {
-    this.presentingElement = document.querySelector('ion-page');
+    this.presentingElement = document.querySelector('ion-router-outlet');
     this.subscription = this.content.isDisabled.subscribe((isDisabled: boolean) => {
       this.isDisabled = isDisabled;
     })

--- a/frontend/src/app/features/modal/modal-view/modal-view.component.ts
+++ b/frontend/src/app/features/modal/modal-view/modal-view.component.ts
@@ -13,6 +13,8 @@ import { CommonModule } from '@angular/common';
 export class ModalViewComponent implements OnInit {
     @ViewChild(IonModal) modal!: IonModal;
     @Input() content!: ModalContent;
+    @Input() title!: string;
+    
     protected isDisabled: boolean = true;
     protected presentingElement!: HTMLElement | null;
     private subscription: any;

--- a/frontend/src/app/features/rit/rate/rate.component.html
+++ b/frontend/src/app/features/rit/rate/rate.component.html
@@ -1,5 +1,8 @@
 <ion-content>
   <ion-card>
+    <ion-card-header>
+      <ion-card-title>Rating</ion-card-title>
+    </ion-card-header>
     <ion-card-content>
       <ion-grid>
         <ion-row>

--- a/frontend/src/app/features/rit/rate/rate.component.html
+++ b/frontend/src/app/features/rit/rate/rate.component.html
@@ -1,12 +1,3 @@
-<ion-header>
-  <ion-toolbar>
-    <ion-buttons slot="start">
-      <ion-back-button></ion-back-button>
-    </ion-buttons>
-    <ion-title>Ratings</ion-title>
-  </ion-toolbar>
-</ion-header>
-
 <ion-content>
   <ion-card>
     <ion-card-content>

--- a/frontend/src/app/features/rit/rate/rate.component.html
+++ b/frontend/src/app/features/rit/rate/rate.component.html
@@ -1,9 +1,14 @@
-<ion-content>
+<ion-header>
+  <ion-toolbar>
+    <ion-buttons slot="start">
+      <ion-back-button></ion-back-button>
+    </ion-buttons>
+    <ion-title>Ratings</ion-title>
+  </ion-toolbar>
+</ion-header>
 
+<ion-content>
   <ion-card>
-    <ion-card-header>
-      <ion-card-title>Rating</ion-card-title>
-    </ion-card-header>
     <ion-card-content>
       <ion-grid>
         <ion-row>

--- a/frontend/src/app/features/rit/rate/rate.component.ts
+++ b/frontend/src/app/features/rit/rate/rate.component.ts
@@ -8,7 +8,7 @@ import { Rit } from '../../../model/rit';
 import { Rating } from '../../../model/rating';
 import { RitService } from '../../../shared/services/rit.service';
 import { ModalContent } from '../../modal/modal-view/modal-view.component';
-import { ToastController } from '@ionic/angular/standalone';
+import { ToastController, IonBackButton } from '@ionic/angular/standalone';
 
 addIcons({ star, 'star-outline': starOutline });
 
@@ -16,7 +16,7 @@ addIcons({ star, 'star-outline': starOutline });
   selector: 'app-rate',
   templateUrl: './rate.component.html',
   styleUrls: ['./rate.component.scss'],
-  imports: [CommonModule, ...IonicStandaloneStandardImports],
+  imports: [IonBackButton, CommonModule, ...IonicStandaloneStandardImports],
   standalone: true,
 })
 export class RateComponent implements ModalContent{

--- a/frontend/src/app/features/rit/rate/rate.component.ts
+++ b/frontend/src/app/features/rit/rate/rate.component.ts
@@ -1,14 +1,14 @@
 import { CommonModule } from '@angular/common';
 import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { ToastController } from '@ionic/angular/standalone';
 import { addIcons } from 'ionicons';
 import { star, starOutline } from 'ionicons/icons';
-import { IonicStandaloneStandardImports } from '../../../shared/ionic-imports';
 import { Observable } from 'rxjs';
-import { Rit } from '../../../model/rit';
 import { Rating } from '../../../model/rating';
+import { Rit } from '../../../model/rit';
+import { IonicStandaloneStandardImports } from '../../../shared/ionic-imports';
 import { RitService } from '../../../shared/services/rit.service';
 import { ModalContent } from '../../modal/modal-view/modal-view.component';
-import { ToastController, IonBackButton } from '@ionic/angular/standalone';
 
 addIcons({ star, 'star-outline': starOutline });
 
@@ -16,14 +16,14 @@ addIcons({ star, 'star-outline': starOutline });
   selector: 'app-rate',
   templateUrl: './rate.component.html',
   styleUrls: ['./rate.component.scss'],
-  imports: [IonBackButton, CommonModule, ...IonicStandaloneStandardImports],
+  imports: [CommonModule, ...IonicStandaloneStandardImports],
   standalone: true,
 })
-export class RateComponent implements ModalContent{
-  @Input() rit!: Observable<Rit|null> | null;
+export class RateComponent implements ModalContent {
+  @Input() rit!: Observable<Rit | null> | null;
   @Output() isDisabled = new EventEmitter<boolean>();
   private ritSubscription: any;
-  protected currentRit: Rit|null = null;
+  protected currentRit: Rit | null = null;
 
   constructor(private readonly ritService: RitService, private readonly toastController: ToastController) { }
 
@@ -91,10 +91,10 @@ export class RateComponent implements ModalContent{
     await toast.present();
   }
 
-  
+
   private buildRequest(): Rating {
     return {
-      rit: {id: this.currentRit?.id},
+      rit: { id: this.currentRit?.id },
       value: this.rating,
       positiveComment: this.positiveComment,
       negativeComment: this.negativeComment,

--- a/frontend/src/app/features/rit/rit-create/rit-create.component.html
+++ b/frontend/src/app/features/rit/rit-create/rit-create.component.html
@@ -1,7 +1,7 @@
 <ion-header *ngIf="mode !== 'create'">
   <ion-toolbar>
     <ion-buttons slot="start">
-      <ion-back-button defaultHref="/rits"></ion-back-button>
+      <ion-back-button></ion-back-button>
     </ion-buttons>
     <ion-title>Rit</ion-title>
 

--- a/frontend/src/app/features/rit/rit-create/rit-create.component.ts
+++ b/frontend/src/app/features/rit/rit-create/rit-create.component.ts
@@ -64,6 +64,10 @@ export class RitCreateComponent implements ViewWillEnter, ModalContent {
       this.ritService.createRit(this.buildRequest()).subscribe({
         next: (rit) => {
           this.handleSuccess(rit, 'Rit created successfully!');
+          this.ritId = undefined;
+          this.ritName = undefined;
+          this.details = undefined;
+          this.tags = [];
           resolve(true);
         },
         error: (err) => {

--- a/frontend/src/app/features/rit/rit-list-item/rit-list-item.component.spec.ts
+++ b/frontend/src/app/features/rit/rit-list-item/rit-list-item.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { IonicModule } from '@ionic/angular';
+import { IonicModule, NavController } from '@ionic/angular';
 import { RitListItemComponent } from './rit-list-item.component';
 import { Rit } from '../../../model/rit';
 import { By } from '@angular/platform-browser';
@@ -8,7 +8,8 @@ import { Router } from '@angular/router';
 describe('RitListItemComponent', () => {
   let component: RitListItemComponent;
   let fixture: ComponentFixture<RitListItemComponent>;
-  let routerSpy: jasmine.SpyObj<Router> = jasmine.createSpyObj('Router', ['navigate']);
+  let routerSpy: jasmine.SpyObj<Router>;
+  let navCtrlSpy: jasmine.SpyObj<NavController>;
 
   const testRit: Rit = {
     id: '1',
@@ -18,10 +19,15 @@ describe('RitListItemComponent', () => {
   };
 
   beforeEach(async () => {
+    routerSpy = jasmine.createSpyObj('Router', ['navigate'], { url: '/tabs/rits' });
+    navCtrlSpy = jasmine.createSpyObj('NavController', ['navigateForward']);
 
     await TestBed.configureTestingModule({
       imports: [RitListItemComponent, IonicModule.forRoot()],
-      providers: [{ provide: Router, useValue: routerSpy }],
+      providers: [
+        { provide: Router, useValue: routerSpy },
+        { provide: NavController, useValue: navCtrlSpy }
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(RitListItemComponent);
@@ -35,10 +41,10 @@ describe('RitListItemComponent', () => {
   });
 
   it('should render rit name and tags', () => {
-    const titleEl = fixture.debugElement.query(By.css('.title')).nativeElement;
+    const titleEl = fixture.debugElement.query(By.css('.title'))?.nativeElement;
     const chipElements = fixture.debugElement.queryAll(By.css('ion-chip'));
 
-    expect(titleEl.textContent).toContain(testRit.name);
+    expect(titleEl?.textContent).toContain(testRit.name);
     expect(chipElements.length).toBe(testRit.tags.length);
     chipElements.forEach((chipEl, index) => {
       expect(chipEl.nativeElement.textContent).toContain(testRit.tags[index]);
@@ -68,13 +74,11 @@ describe('RitListItemComponent', () => {
 
   it('should navigate to ratings with correct ID', () => {
     component.navigateToRatings();
-    expect(routerSpy.navigate).toHaveBeenCalledWith(['/rits/ratings', testRit.id]);
+    expect(navCtrlSpy.navigateForward).toHaveBeenCalledWith('/tabs/rits/ratings/1');
   });
 
   it('should navigate to rit view with correct ID', () => {
     component.navigateToRit();
-    expect(routerSpy.navigate).toHaveBeenCalledWith(['/rits/view', testRit.id]);
+    expect(navCtrlSpy.navigateForward).toHaveBeenCalledWith('/tabs/rits/view/1');
   });
-
-
 });

--- a/frontend/src/app/features/rit/rit-list-item/rit-list-item.component.ts
+++ b/frontend/src/app/features/rit/rit-list-item/rit-list-item.component.ts
@@ -1,9 +1,9 @@
-import {CommonModule} from '@angular/common';
-import {Component, Input} from '@angular/core';
-import {Router} from '@angular/router';
-import {Rit} from '../../../model/rit';
-import {IonicStandaloneStandardImports} from '../../../shared/ionic-imports';
-import {Rating} from '../../../model/rating';
+import { CommonModule } from '@angular/common';
+import { Component, Input } from '@angular/core';
+import { Router } from '@angular/router';
+import { Rating } from '../../../model/rating';
+import { Rit } from '../../../model/rit';
+import { IonicStandaloneStandardImports } from '../../../shared/ionic-imports';
 
 @Component({
   selector: 'app-rit-list-item',
@@ -15,6 +15,7 @@ import {Rating} from '../../../model/rating';
 
 export class RitListItemComponent {
   @Input() rit!: Rit;
+  @Input() currentPage!: string;
 
   protected latestRatingValue: number = 0;
 
@@ -37,11 +38,11 @@ export class RitListItemComponent {
   }
 
   navigateToRatings(): void {
-    this.router.navigate(['/rits/ratings', this.rit.id]);
+    this.router.navigate(this.currentPage === 'home' ? ['home/rits/ratings', this.rit.id] : ['/rits/ratings', this.rit.id]);
   }
 
   navigateToRit(): void {
-    this.router.navigate(['/rits/view', this.rit.id]);
+    this.router.navigate(this.currentPage === 'home' ? ['/home/rits/view', this.rit.id] : ['/rits/view', this.rit.id]);
   }
 
 }

--- a/frontend/src/app/features/rit/rit-list-item/rit-list-item.component.ts
+++ b/frontend/src/app/features/rit/rit-list-item/rit-list-item.component.ts
@@ -4,6 +4,7 @@ import { Router } from '@angular/router';
 import { Rating } from '../../../model/rating';
 import { Rit } from '../../../model/rit';
 import { IonicStandaloneStandardImports } from '../../../shared/ionic-imports';
+import { NavController } from '@ionic/angular';
 
 @Component({
   selector: 'app-rit-list-item',
@@ -15,11 +16,10 @@ import { IonicStandaloneStandardImports } from '../../../shared/ionic-imports';
 
 export class RitListItemComponent {
   @Input() rit!: Rit;
-  @Input() currentPage!: string;
 
   protected latestRatingValue: number = 0;
 
-  constructor(private readonly router: Router) {
+  constructor(private readonly router: Router, private readonly navCtrl: NavController) {
   }
 
   ngOnInit() {
@@ -37,12 +37,22 @@ export class RitListItemComponent {
     return latestRating.value ?? 0;
   }
 
+  private isInHomeTab(): boolean {
+    return this.router.url.includes('/tabs/home');
+  }
+
   navigateToRatings(): void {
-    this.router.navigate(this.currentPage === 'home' ? ['home/rits/ratings', this.rit.id] : ['/rits/ratings', this.rit.id]);
+    const path = this.isInHomeTab()
+      ? `/tabs/home/rits/ratings/${this.rit.id}`
+      : `/tabs/rits/ratings/${this.rit.id}`;
+    this.navCtrl.navigateForward(path);
   }
 
   navigateToRit(): void {
-    this.router.navigate(this.currentPage === 'home' ? ['/home/rits/view', this.rit.id] : ['/rits/view', this.rit.id]);
+    const path = this.isInHomeTab()
+      ? `/tabs/home/rits/view/${this.rit.id}`
+      : `/tabs/rits/view/${this.rit.id}`;
+    this.navCtrl.navigateForward(path);
   }
 
 }

--- a/frontend/src/app/features/tabs/all-rits/all-rits.component.html
+++ b/frontend/src/app/features/tabs/all-rits/all-rits.component.html
@@ -23,7 +23,7 @@
     <ion-refresher-content></ion-refresher-content>
   </ion-refresher>
   <ion-list>
-    <app-rit-list-item [currentPage]="'rits'" *ngFor="let rit of filteredRits()" [rit]="rit">
+    <app-rit-list-item *ngFor="let rit of filteredRits()" [rit]="rit">
     </app-rit-list-item>
   </ion-list>
 </ion-content>

--- a/frontend/src/app/features/tabs/all-rits/all-rits.component.html
+++ b/frontend/src/app/features/tabs/all-rits/all-rits.component.html
@@ -23,7 +23,7 @@
     <ion-refresher-content></ion-refresher-content>
   </ion-refresher>
   <ion-list>
-    <app-rit-list-item *ngFor="let rit of filteredRits()" [rit]="rit">
+    <app-rit-list-item [currentPage]="'rits'" *ngFor="let rit of filteredRits()" [rit]="rit">
     </app-rit-list-item>
   </ion-list>
 </ion-content>

--- a/frontend/src/app/features/tabs/home/home.component.html
+++ b/frontend/src/app/features/tabs/home/home.component.html
@@ -19,7 +19,7 @@
     <ion-refresher-content></ion-refresher-content>
   </ion-refresher>
   <ion-list>
-    <app-rit-list-item *ngFor="let rit of latestRits()" [rit]="rit">
+    <app-rit-list-item [currentPage]="'home'" *ngFor="let rit of latestRits()" [rit]="rit">
     </app-rit-list-item>
   </ion-list>
 </ion-content>

--- a/frontend/src/app/features/tabs/home/home.component.html
+++ b/frontend/src/app/features/tabs/home/home.component.html
@@ -19,7 +19,7 @@
     <ion-refresher-content></ion-refresher-content>
   </ion-refresher>
   <ion-list>
-    <app-rit-list-item [currentPage]="'home'" *ngFor="let rit of latestRits()" [rit]="rit">
+    <app-rit-list-item *ngFor="let rit of latestRits()" [rit]="rit">
     </app-rit-list-item>
   </ion-list>
 </ion-content>

--- a/frontend/src/app/features/tabs/home/home.component.ts
+++ b/frontend/src/app/features/tabs/home/home.component.ts
@@ -115,7 +115,7 @@ export class HomeComponent implements ViewWillEnter {
   }
 
   goToRitsTab() {
-    this.router.navigate(['/rits']);
+    this.router.navigate(['/tabs/rits']);
   }
 
   handleRefresh(event: CustomEvent) {

--- a/frontend/src/app/features/tabs/login/login.component.spec.ts
+++ b/frontend/src/app/features/tabs/login/login.component.spec.ts
@@ -75,7 +75,7 @@ describe('LoginComponent', () => {
 
   it('should navigate to register page when register is called', () => {
     component.register();
-    expect(routerSpy.navigate).toHaveBeenCalledWith(['/register']);
+    expect(routerSpy.navigate).toHaveBeenCalledWith(['/tabs/register']);
   });
 
   it('should set errorMessage and clear password on login error', () => {

--- a/frontend/src/app/features/tabs/login/login.component.ts
+++ b/frontend/src/app/features/tabs/login/login.component.ts
@@ -29,7 +29,7 @@ export class LoginComponent implements OnInit {
 
   ionViewWillEnter() {
     this.route.snapshot.queryParams['emailConfirmed'] && this.showSuccessToast('Email confirmed successfully!');
-    this.router.navigate(['/login'], { queryParams: { emailConfirmed: null } });
+    this.router.navigate(['/tabs/login'], { queryParams: { emailConfirmed: null } });
     this.reset();
   }
 
@@ -56,7 +56,7 @@ export class LoginComponent implements OnInit {
   }
 
   register() {
-    this.router.navigate(['/register']);
+    this.router.navigate(['/tabs/register']);
   }
 
   async showSuccessToast(message: string) {

--- a/frontend/src/app/features/tabs/mail-confirmation/mail-confirmation.component.spec.ts
+++ b/frontend/src/app/features/tabs/mail-confirmation/mail-confirmation.component.spec.ts
@@ -1,14 +1,12 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { TestBed, waitForAsync } from '@angular/core/testing';
 
-import { MailConfirmationComponent } from './mail-confirmation.component';
-import { CommonModule } from '@angular/common';
-import { IonicStandaloneStandardImports } from '../../../shared/ionic-imports';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { Router } from '@angular/router';
-import { provideMockApiService } from '../../../shared/test-util/test-util';
+import { of, throwError } from 'rxjs';
 import { ApiService } from '../../../shared/services/api.service';
-import { Observable, of, throwError } from 'rxjs';
+import { provideMockApiService } from '../../../shared/test-util/test-util';
+import { MailConfirmationComponent } from './mail-confirmation.component';
 
 describe('MailConfirmationComponent', () => {
   beforeEach(waitForAsync(() => {
@@ -39,7 +37,7 @@ describe('MailConfirmationComponent', () => {
     apiServiceSpy.get.and.returnValue(of({}));
     const fixture = TestBed.createComponent(MailConfirmationComponent);
     fixture.detectChanges();
-    expect(routerSpy.navigate).toHaveBeenCalledWith(['/login'], { queryParams: { emailConfirmed: true } });
+    expect(routerSpy.navigate).toHaveBeenCalledWith(['/tabs/login'], { queryParams: { emailConfirmed: true } });
   });
 
   it('should not redirect to /login on ngOnInit if api-call failed', () => {
@@ -50,6 +48,6 @@ describe('MailConfirmationComponent', () => {
     apiServiceSpy.get.and.returnValue(throwError(() => new Error('Error')));
     const fixture = TestBed.createComponent(MailConfirmationComponent);
     fixture.detectChanges();
-    expect(routerSpy.navigate).not.toHaveBeenCalledWith(['/login'], { queryParams: { emailConfirmed: true } });
+    expect(routerSpy.navigate).not.toHaveBeenCalledWith(['/tabs/login'], { queryParams: { emailConfirmed: true } });
   });
 });

--- a/frontend/src/app/features/tabs/mail-confirmation/mail-confirmation.component.ts
+++ b/frontend/src/app/features/tabs/mail-confirmation/mail-confirmation.component.ts
@@ -21,7 +21,7 @@ export class MailConfirmationComponent  implements OnInit {
       {
         next: (response) => {
           console.log('Email confirmed successfully:', response);
-          this.router.navigate(['/login'], { queryParams: { emailConfirmed: true } });
+          this.router.navigate(['/tabs/login'], { queryParams: { emailConfirmed: true } });
         },
         error: (error) => {
           console.error('Error confirming email:', error.error);

--- a/frontend/src/app/features/tabs/profile/profile.component.spec.ts
+++ b/frontend/src/app/features/tabs/profile/profile.component.spec.ts
@@ -52,7 +52,7 @@ describe('ProfileComponent', () => {
     expect(component.profile).toEqual(mockProfile);
   });
 
-  it('should call AuthService.logout and navigate to /home on logout', () => {
+  it('should call AuthService.logout and navigate to /tabs/home on logout', () => {
     const routerSpy = jasmine.createSpyObj('Router', ['navigate']);
 
 
@@ -65,7 +65,7 @@ describe('ProfileComponent', () => {
     component.logout();
 
     expect(authServiceSpy.logout).toHaveBeenCalled();
-    expect(routerSpy.navigate).toHaveBeenCalledWith(['/home']);
+    expect(routerSpy.navigate).toHaveBeenCalledWith(['/tabs/home']);
   });
 
 });

--- a/frontend/src/app/features/tabs/profile/profile.component.ts
+++ b/frontend/src/app/features/tabs/profile/profile.component.ts
@@ -42,7 +42,7 @@ export class ProfileComponent {
 
   logout() {
     this.authService.logout();
-    this.router.navigate(['/home']);
+    this.router.navigate(['/tabs/home']);
   }
 
 }

--- a/frontend/src/app/features/tabs/tab-menu/tab-menu.component.html
+++ b/frontend/src/app/features/tabs/tab-menu/tab-menu.component.html
@@ -1,21 +1,21 @@
 <ion-tabs>
   <ion-tab-bar slot="bottom">
-    <ion-tab-button tab="home" (click)="navigateToTab('home')">
+    <ion-tab-button tab="home" (click)="navigateToTab('home')" (keydown.enter)="navigateToTab('home')">
       <ion-icon name="home-outline"></ion-icon>
       Home
     </ion-tab-button>
 
-    <ion-tab-button *ngIf="isAuthenticated" tab="rits" (click)="navigateToTab('rits')">
+    <ion-tab-button *ngIf="isAuthenticated" tab="rits" (click)="navigateToTab('rits')" (keydown.enter)="navigateToTab('rits')">
       <ion-icon name="star-outline"></ion-icon>
       Rits
     </ion-tab-button>
 
-    <ion-tab-button *ngIf="!isAuthenticated" tab="login" (click)="navigateToTab('login')">
+    <ion-tab-button *ngIf="!isAuthenticated" tab="login" (click)="navigateToTab('login')" (keydown.enter)="navigateToTab('login')">
       <ion-icon name="log-in-outline"></ion-icon>
       Login
     </ion-tab-button>
 
-    <ion-tab-button *ngIf="isAuthenticated" tab="profile" (click)="navigateToTab('profile')">
+    <ion-tab-button *ngIf="isAuthenticated" tab="profile" (click)="navigateToTab('profile')" (keydown.enter)="navigateToTab('profile')">
       <ion-icon name="person-outline"></ion-icon>
       Profile
     </ion-tab-button>

--- a/frontend/src/app/features/tabs/tab-menu/tab-menu.component.html
+++ b/frontend/src/app/features/tabs/tab-menu/tab-menu.component.html
@@ -1,18 +1,21 @@
 <ion-tabs>
   <ion-tab-bar slot="bottom">
-    <ion-tab-button tab="home">
-      <ion-icon name='home-outline'></ion-icon>
+    <ion-tab-button tab="home" (click)="navigateToTab('home')">
+      <ion-icon name="home-outline"></ion-icon>
       Home
     </ion-tab-button>
-    <ion-tab-button *ngIf="isAuthenticated" tab="rits">
-      <ion-icon name='star-outline'></ion-icon>
+
+    <ion-tab-button *ngIf="isAuthenticated" tab="rits" (click)="navigateToTab('rits')">
+      <ion-icon name="star-outline"></ion-icon>
       Rits
     </ion-tab-button>
-    <ion-tab-button *ngIf="!isAuthenticated" tab="login">
+
+    <ion-tab-button *ngIf="!isAuthenticated" tab="login" (click)="navigateToTab('login')">
       <ion-icon name="log-in-outline"></ion-icon>
       Login
     </ion-tab-button>
-    <ion-tab-button *ngIf="isAuthenticated" tab="profile">
+
+    <ion-tab-button *ngIf="isAuthenticated" tab="profile" (click)="navigateToTab('profile')">
       <ion-icon name="person-outline"></ion-icon>
       Profile
     </ion-tab-button>

--- a/frontend/src/app/features/tabs/tab-menu/tab-menu.component.spec.ts
+++ b/frontend/src/app/features/tabs/tab-menu/tab-menu.component.spec.ts
@@ -2,14 +2,13 @@ import { TestBed } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { TabMenuComponent } from './tab-menu.component';
-import { ActivatedRoute, provideRouter } from '@angular/router';
+import { provideRouter } from '@angular/router';
 import { routes } from '../../../app.routes';
 import { AuthService } from '../../../shared/services/auth.service';
-import { of } from 'rxjs';
-import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideMockAuthService } from '../../../shared/test-util/test-util';
+import { TabMenuComponent } from './tab-menu.component';
 
 describe('TabMenuComponent', () => {
   beforeEach(async () => {

--- a/frontend/src/app/features/tabs/tab-menu/tab-menu.component.ts
+++ b/frontend/src/app/features/tabs/tab-menu/tab-menu.component.ts
@@ -39,14 +39,8 @@ export class TabMenuComponent {
 
   navigateToTab(tab: string) {
     const currentUrl = this.router.url;
-
     const tabRootPath = `/tabs/${tab}`;
-
-    if (!currentUrl.startsWith(tabRootPath)) {
-      this.navCtrl.navigateRoot(tabRootPath);
-      return;
-    }
-
+    
     if (currentUrl !== tabRootPath) {
       this.navCtrl.navigateRoot(tabRootPath);
     }

--- a/frontend/src/app/features/tabs/tab-menu/tab-menu.component.ts
+++ b/frontend/src/app/features/tabs/tab-menu/tab-menu.component.ts
@@ -1,10 +1,10 @@
 import { CommonModule } from '@angular/common';
 import { Component } from '@angular/core';
-import { IonicStandaloneStandardImports } from '../../../shared/ionic-imports';
-import { AuthService } from '../../../shared/services/auth.service';
-import { Subscription } from 'rxjs';
 import { Router } from '@angular/router';
 import { NavController } from '@ionic/angular';
+import { Subscription } from 'rxjs';
+import { IonicStandaloneStandardImports } from '../../../shared/ionic-imports';
+import { AuthService } from '../../../shared/services/auth.service';
 
 @Component({
   selector: 'app-tab-menu',

--- a/frontend/src/app/features/tabs/tab-menu/tab-menu.component.ts
+++ b/frontend/src/app/features/tabs/tab-menu/tab-menu.component.ts
@@ -3,6 +3,8 @@ import { Component } from '@angular/core';
 import { IonicStandaloneStandardImports } from '../../../shared/ionic-imports';
 import { AuthService } from '../../../shared/services/auth.service';
 import { Subscription } from 'rxjs';
+import { Router } from '@angular/router';
+import { NavController } from '@ionic/angular';
 
 @Component({
   selector: 'app-tab-menu',
@@ -14,9 +16,14 @@ import { Subscription } from 'rxjs';
   ]
 })
 export class TabMenuComponent {
-  private authSubscription: Subscription|null = null;
+  private authSubscription: Subscription | null = null;
   isAuthenticated: boolean = false;
-  constructor(private readonly authService: AuthService) { }
+
+  constructor(
+    private readonly authService: AuthService,
+    private readonly router: Router,
+    private readonly navCtrl: NavController
+  ) { }
 
   ionViewWillEnter() {
     this.authSubscription = this.authService.getAuthenticationStatusObservable().subscribe({
@@ -28,5 +35,20 @@ export class TabMenuComponent {
 
   ionViewWillLeave() {
     this.authSubscription?.unsubscribe();
+  }
+
+  navigateToTab(tab: string) {
+    const currentUrl = this.router.url;
+
+    const tabRootPath = `/tabs/${tab}`;
+
+    if (!currentUrl.startsWith(tabRootPath)) {
+      this.navCtrl.navigateRoot(tabRootPath);
+      return;
+    }
+
+    if (currentUrl !== tabRootPath) {
+      this.navCtrl.navigateRoot(tabRootPath);
+    }
   }
 }

--- a/frontend/src/app/shared/guards/auth.guard.spec.ts
+++ b/frontend/src/app/shared/guards/auth.guard.spec.ts
@@ -41,7 +41,7 @@ describe('AuthGuard', () => {
 
   it('should deny activation and redirect to login if user is not authenticated', () => {
     expect(authGuard.canActivate(new ActivatedRouteSnapshot(), <RouterStateSnapshot>{url: 'testUrl'})).toBeFalse();
-    expect(routerSpy.navigate).toHaveBeenCalledWith(['/login'], Object({ queryParams: Object({ returnUrl: "testUrl" }) }));
+    expect(routerSpy.navigate).toHaveBeenCalledWith(['/tabs/login'], Object({ queryParams: Object({ returnUrl: "testUrl" }) }));
   });
 });
 

--- a/frontend/src/app/shared/guards/auth.guard.ts
+++ b/frontend/src/app/shared/guards/auth.guard.ts
@@ -15,7 +15,7 @@ export class AuthGuard implements CanActivate {
     if(this.authService.isAuthenticated()) {
       return true;
     }
-    this.router.navigate(['/login'], {queryParams: {returnUrl: state.url}});
+    this.router.navigate(['/tabs/login'], {queryParams: {returnUrl: state.url}});
 
     return false;
   }

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8">
-  <title>Frontend</title>
+  <title>Rateit</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">


### PR DESCRIPTION
- Zeige neu beim Fab-Button nur noch createRit im Rit Kontext sowie createRating im Rating Kontext
  - Ich habe ihn aber trotzdem mal noch gelassen für den QR Code später
- Browser Tab auf Rateit umbenannt
- RitCreate Felder zurückgesetzt nach Erstellung
- Routing / Tab Setup angepasst

Einerseits hab ich wie besprochen die beiden /home und /rits Routings separiert, damit man auf dem eigenen Tab bleibt und auch der Back Button richtig funktioniert. Allerdings hab ich gesehen, dass bei uns das TabMenu Setup allgemein noch etwas buggy war, was zu Animationen in die falsche Richtung, Rendering-Verzögerungen etc. führte.

Dafür musste ich in den AppRoutes die Parent-Route vom TabMenu auf /tabs/ setzen statt '', damit Ionic die Tabs richtig erkennt. Das hat zur Folge, dass alle Routes neu mit /tabs/** beginnen.
Ausserdem soll man neu, solange man sich im gleichen Tab befindet, mit dem NavController von Ionic navigieren, damit das mit den Animationen richtig funktioniert (bsw. mit `this.navCtrl.navigateForward(path);`. Sobald man allerdings den Tab absichtlich wechselt (wie bspw. beim "Show All"), nach wie vor mit router.navigate arbeiten.