### PR TITLE
Small refactorings/bugfixes

### DIFF
--- a/api/docker/Dockerfile
+++ b/api/docker/Dockerfile
@@ -1,9 +1,9 @@
 FROM gradle:8.13.0-jdk-alpine AS build
 
-COPY --chown=gradle:gradle --chmod=755 api/settings.gradle /app/settings.gradle
-COPY --chown=gradle:gradle --chmod=755 api/build.gradle /app/build.gradle
-COPY --chown=gradle:gradle --chmod=755 api/src /app/src
-COPY --chown=gradle:gradle --chmod=755 .git/ /.git/
+COPY --chown=gradle:gradle --chmod=744 api/settings.gradle /app/settings.gradle
+COPY --chown=gradle:gradle --chmod=744 api/build.gradle /app/build.gradle
+COPY --chown=gradle:gradle --chmod=744 api/src /app/src
+COPY --chown=gradle:gradle --chmod=744 .git/ /.git/
 WORKDIR /app
 
 RUN gradle bootJar --no-daemon

--- a/frontend/git-version.js
+++ b/frontend/git-version.js
@@ -4,7 +4,6 @@ const { resolve, relative } = require('path');
 const { writeFileSync, existsSync, mkdirSync } = require('fs-extra');
 
 getLastCommit((err, gitInfo) => {    
-
     gitInfo.version = version;
     gitInfo.authoredOn = new Date(parseInt(gitInfo.authoredOn) * 1000);
     gitInfo.committedOn = new Date(parseInt(gitInfo.committedOn) * 1000);

--- a/frontend/sonar-project.properties
+++ b/frontend/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.projectKey=rateit-pm4-org_rateit-frontend
 sonar.organization=rateit-pm4-org
 
-sonar.sources.exclusions=**/node_modules/**,**/test-results/**, **/.angular/**
+sonar.sources.exclusions=**/node_modules/**,**/test-results/**, **/.angular/**, git-version.js
 sonar.test.inclusions=**/*.spec.ts
 
 sonar.testExecutionReportPaths=test-results/report-sonar.xml


### PR DESCRIPTION
- security improvement: read only copies of files in Dockerfile for api
- ignored git-version.js from sonar-scan (as it's not needed to be tested, is an init-script) => hopefully it works, if not we leave it as is

can be merged directly by reviewer, docker build was tested locally by myself