### PR TITLE
Add Github-Workflow: Build Docker-Images in PR to stage and post comment

### DIFF
--- a/.github/workflows/module-docker-image-build-push.yml
+++ b/.github/workflows/module-docker-image-build-push.yml
@@ -19,7 +19,7 @@ on:
       imageDigest:
         value: ${{ jobs.build-and-push-image.outputs.imageDigest }}     
       image:
-        value: ${{ vars.REGISTRY}}/${{ vars.ORG_NAME}}/${{ inputs.imageName }}:${{ inputs.imageTag }}  
+        value: ${{ inputs.imageName }}:${{ inputs.imageTag }}  
   workflow_dispatch:
     inputs:
       imageName:

--- a/.github/workflows/module-docker-image-build-push.yml
+++ b/.github/workflows/module-docker-image-build-push.yml
@@ -18,6 +18,8 @@ on:
     outputs:
       imageDigest:
         value: ${{ jobs.build-and-push-image.outputs.imageDigest }}     
+      image:
+        value: ${{ vars.REGISTRY}}/${{ vars.ORG_NAME}}/${{ inputs.imageName }}:${{ inputs.imageTag }}  
   workflow_dispatch:
     inputs:
       imageName:

--- a/.github/workflows/stage-build-PR.yml
+++ b/.github/workflows/stage-build-PR.yml
@@ -37,13 +37,14 @@ jobs:
         needs:  [build-and-push-image-frontend, build-and-push-image-api]
         name: Comment on PR
         runs-on: ubuntu-latest
+        permissions:
+          pull-requests: write
         steps:
           - name: Checkout repository
             uses: actions/checkout@v4
           - name: Comment on PR
             uses: marocchino/sticky-pull-request-comment@v2
             with:
-              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               header: 'Docker Image Digest'
               message: |
                 API Image Digest: `${{needs.build-and-push-image-api.outputs.imageDigest}}`

--- a/.github/workflows/stage-build-PR.yml
+++ b/.github/workflows/stage-build-PR.yml
@@ -47,5 +47,8 @@ jobs:
             with:
               header: 'Docker Image Digest'
               message: |
+                Docker images have been built and pushed successfully.
+                API Image: `${{needs.build-and-push-image-api.outputs.image}}`
                 API Image Digest: `${{needs.build-and-push-image-api.outputs.imageDigest}}`
+                Frontend Image: `${{needs.build-and-push-image-frontend.outputs.image}}`
                 Frontend Image Digest: `${{needs.build-and-push-image-frontend.outputs.imageDigest}}`

--- a/.github/workflows/stage-build-PR.yml
+++ b/.github/workflows/stage-build-PR.yml
@@ -46,6 +46,7 @@ jobs:
             uses: marocchino/sticky-pull-request-comment@v2
             with:
               header: 'Docker Image Digest'
+              recreate: true
               message: |
                 Docker images have been built and pushed successfully.
                 API Image: `${{needs.build-and-push-image-api.outputs.image}}`

--- a/.github/workflows/stage-build-PR.yml
+++ b/.github/workflows/stage-build-PR.yml
@@ -1,11 +1,8 @@
-name: CD Stage
+name: PR Build and Push Docker Images
 on: 
   workflow_dispatch:
   workflow_call:
   pull_request:
-      paths:
-        - 'api/**'
-        - 'frontend/**'
       branches:
         - stage
 

--- a/.github/workflows/stage-build-PR.yml
+++ b/.github/workflows/stage-build-PR.yml
@@ -1,0 +1,53 @@
+name: CD Stage
+on: 
+  workflow_dispatch:
+  workflow_call:
+  pull_request:
+      paths:
+        - 'api/**'
+        - 'frontend/**'
+      branches:
+        - stage
+
+jobs:
+  build-and-push-image-api:
+    name: Build and Push Docker Image API
+    uses: ./.github/workflows/module-docker-image-build-push.yml
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    with:
+      imageName: rateit-api
+      imageTag: pr-${{ github.event.pull_request.number }}
+      dockerFilePath: api/docker/Dockerfile
+      buildPath: .
+  build-and-push-image-frontend:
+        name: Build and Push Docker Image Frontend
+        uses: ./.github/workflows/module-docker-image-build-push.yml
+        permissions:
+          contents: read
+          packages: write
+          attestations: write
+          id-token: write
+        with:
+          imageName: rateit-frontend
+          imageTag: ${{ github.event.pull_request.number }}
+          dockerFilePath: frontend/Dockerfile
+          buildPath: .
+  comment-on-pr:
+        needs:  [build-and-push-image-frontend, build-and-push-image-api]
+        name: Comment on PR
+        runs-on: ubuntu-latest
+        steps:
+          - name: Checkout repository
+            uses: actions/checkout@v4
+          - name: Comment on PR
+            uses: marocchino/sticky-pull-request-comment@v2
+            with:
+              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              header: 'Docker Image Digest'
+              message: |
+                API Image Digest: `${{needs.build-and-push-image-api.outputs.imageDigest}}`
+                Frontend Image Digest: `${{needs.build-and-push-image-frontend.outputs.imageDigest}}`

--- a/.github/workflows/stage-build-PR.yml
+++ b/.github/workflows/stage-build-PR.yml
@@ -30,7 +30,7 @@ jobs:
           id-token: write
         with:
           imageName: rateit-frontend
-          imageTag: ${{ github.event.pull_request.number }}
+          imageTag: pr-${{ github.event.pull_request.number }}
           dockerFilePath: frontend/Dockerfile
           buildPath: .
   comment-on-pr:


### PR DESCRIPTION
Added an additional Github-Workflow which builds and pushes both Docker-Images in Pull-Requests and comments about the new images.
The goal is to check, that the build is also functioning in the Docker-Context and also to provide the images directly.

The final image is still build on stage-branch for the deployments.

Please do not merge yourself, i'll activate the check-requirement on merge.