### PR TITLE
disabled ionic swipe gestures & zooming

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -1,3 +1,3 @@
 <ion-app>
-  <ion-router-outlet></ion-router-outlet>
+  <ion-router-outlet [swipeGesture]="false"></ion-router-outlet>
 </ion-app>

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8">
   <title>Rateit</title>
   <base href="/">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, maximum-scale=1, user-scalable=no">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="icons/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="icons/favicon-32x32.png">


### PR DESCRIPTION
Versuch, das Problem mit der doppelten Swipe Animation zu fixen, indem ich die Ionic Swipe Animationen deaktiviere (Vorschlag von ChatGPT).

Ausserdem habe ich noch das manuelle Zooming rausgenommen, da ich das Verhalten etwas unpassend finde für eine App (kann man ja typischerweise nicht reinzoomen wie auf einer Webseite).

Gerne nicht selbstständig mergen, will schauen wie es aussieht in der Stage.