### PR TITLE
278-unstable-layout-homecomponent

### DIFF
--- a/frontend/src/app/features/tabs/home/home.component.html
+++ b/frontend/src/app/features/tabs/home/home.component.html
@@ -12,7 +12,7 @@
 <div *ngIf="isLoggedIn$ | async" class="ion-padding-horizontal" scroll-y="false">
   <ion-grid>
     <ion-row>
-      <ion-col size="6" *ngFor="let tag of topTags(); let i = index" data-testid="tag-item">
+      <ion-col size="6" *ngFor="let tag of tags; let i = index" data-testid="tag-item">
         <app-tag-list-item [tag]="tag"></app-tag-list-item>
       </ion-col>
     </ion-row>

--- a/frontend/src/app/features/tabs/home/home.component.ts
+++ b/frontend/src/app/features/tabs/home/home.component.ts
@@ -28,6 +28,7 @@ export class HomeComponent implements ViewWillEnter {
   presentingElement!: HTMLElement | null;
 
   rits: Rit[] = [];
+  tags: any[] = [];
   numberOfLatestRitsToShow: number = 10;
   numberOfTopTagsToShow: number = 4;
   isLoggedIn$!: Observable<boolean>;
@@ -97,7 +98,9 @@ export class HomeComponent implements ViewWillEnter {
       const dateB = this.calculateLastInteractionAt(b);
       return dateB.getTime() - dateA.getTime();
     });
+    this.tags = this.topTags();
   }
+
   private calculateLastInteractionAt(rit: Rit): Date {
     const latestRatingDate = rit.ratings?.reduce((latest, rating) => {
       const ratingDate = new Date(rating.createdAt ?? 0);


### PR DESCRIPTION
Closes #278 

The issue was how the tags were loaded from the html:
In the original version a function was used depending on rits-data.
This function was then triggered a lot by angular (even when no change in rits-data).

The fix:
A property is now used for the tags, and the property is correctly updated on Subscription-Result from Rits-Loading.
This reduces the amount of evaluations and layout changes to a minimum.

Reviewer: please merge directly yourself after local testing