### PR TITLE
bugfix: if rits result is length 0 set to empty rits list

### DIFF
--- a/frontend/src/app/features/tabs/all-rits/all-rits.component.ts
+++ b/frontend/src/app/features/tabs/all-rits/all-rits.component.ts
@@ -79,6 +79,7 @@ export class AllRitsComponent implements ViewWillEnter {
 
   private handleSuccess(data: Rit[]) {
     if (data.length === 0) {
+      this.rits = [];
       return;
     }
     this.rits = [...data];

--- a/frontend/src/app/features/tabs/all-rits/all-rits.component.ts
+++ b/frontend/src/app/features/tabs/all-rits/all-rits.component.ts
@@ -78,10 +78,6 @@ export class AllRitsComponent implements ViewWillEnter {
   }
 
   private handleSuccess(data: Rit[]) {
-    if (data.length === 0) {
-      this.rits = [];
-      return;
-    }
     this.rits = [...data];
   }
 


### PR DESCRIPTION
Löst das Problem mit dem Löschen des letzten Rit in All-Rits.

Gerne selber mergen, ist im Issue erfasst, sobald das Cluster wieder geht.