### PR TITLE
improve delete sliding layout

### DIFF
--- a/frontend/src/app/features/rating/all-ratings/all-ratings.component.html
+++ b/frontend/src/app/features/rating/all-ratings/all-ratings.component.html
@@ -13,7 +13,7 @@
     </ion-text>
 
     <ion-item-sliding class="rating-item ion-margin-bottom" *ngFor="let rating of ratings">
-      <ion-item lines="none" class="ion-no-padding">
+      <ion-item lines="none" class="ion-no-padding rating-container">
         <div class="full-width-wrapper" >
           <app-rating-list-item [rating]="rating"></app-rating-list-item>
         </div>

--- a/frontend/src/app/features/rating/all-ratings/all-ratings.component.scss
+++ b/frontend/src/app/features/rating/all-ratings/all-ratings.component.scss
@@ -2,15 +2,19 @@
   width: 100%;
 }
 
-ion-item{
+ion-item {
   --inner-padding-end: 0px;
 }
 
-ion-item-option{
+ion-item-option {
   border-radius: 20px;
   padding: 15px;
 }
 
 ion-item-options {
   border: 0;
+}
+
+.rating-container {
+  border-radius: 20px;
 }

--- a/frontend/src/app/features/rit/rit-list-item/rit-list-item.component.html
+++ b/frontend/src/app/features/rit/rit-list-item/rit-list-item.component.html
@@ -1,4 +1,4 @@
-<ion-item-sliding class="rit-item ion-margin-bottom">
+<ion-item-sliding class="ion-margin-bottom">
   <ion-item lines="none" class="ion-no-padding">
     <div class="list-item-card full-width-wrapper">
       <ion-label (click)="navigateToRit()" (keydown.enter)="navigateToRit()" class="content">

--- a/frontend/src/app/features/rit/rit-list-item/rit-list-item.component.scss
+++ b/frontend/src/app/features/rit/rit-list-item/rit-list-item.component.scss
@@ -62,6 +62,7 @@ ion-chip:first-child{
 
 ion-item{
   --inner-padding-end: 0px;
+  border-radius: 20px;
 }
 
 ion-item-option{


### PR DESCRIPTION
there was the problem that the swipable items (rit list items and rating list items) are rounded but the container was still squared. 
![image](https://github.com/user-attachments/assets/d14a58fc-0339-432e-accd-192d3083a671)


added border-radius of 20 to all containers

now:

![image](https://github.com/user-attachments/assets/7cd4d03e-2760-4b19-8a88-4b3fabf67321)
