### PR TITLE
bugfix: clear codes on stop in scanner

### DIFF
--- a/frontend/src/app/features/scanner/scanner.component.ts
+++ b/frontend/src/app/features/scanner/scanner.component.ts
@@ -25,6 +25,8 @@ export class ScannerComponent {
 
   stop(): void {
     Quagga.stop();
+    this.scannedCodes.clear();
+    this.recentCodes = [];
   }
 
   private initQuagga(): void {


### PR DESCRIPTION
Fixes the following issue:
- When scanning the same code in modals, the code is only scannable one time (even after reopening scanner-modal)